### PR TITLE
Add Postman collection import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove the legacy Python prototype from the public repository.
 - Add public project-status badges and initial prototype attribution.
 - Add mailmap attribution for Jaykumar Gori's earlier commit identities.
+- Add initial Postman Collection v2.1 import support.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Use Loadwright when you want:
 - JSON, Markdown, HTML, and JUnit summaries
 - CI pass/fail thresholds
 - OpenAPI-to-spec bootstrapping for simple API tests
+- Postman-collection-to-spec bootstrapping for common API workflows
 - future optional AI assistance without depending on AI for normal runs
 
 Current `v0.1.0` scope: HTTP API load tests. See [docs/limitations.md](docs/limitations.md) for known limits.
@@ -100,6 +101,7 @@ More docs:
 - [Install](docs/install.md)
 - [Examples](docs/examples.md)
 - [OpenAPI import](docs/openapi-import.md)
+- [Postman import](docs/postman-import.md)
 - [Data sources](docs/data-sources.md)
 - [CI](docs/ci.md)
 - [Reports](docs/reports.md)
@@ -115,6 +117,7 @@ loadwright doctor [--deep] [--image justb4/jmeter:latest]
 loadwright version
 loadwright init [path]
 loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
+loadwright import postman <collection.json> [-o loadwright.yaml] [--base-url https://api.example.com]
 loadwright validate <spec.yaml> [--env-file .env.test]
 loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
 loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]
@@ -128,7 +131,7 @@ loadwright report <results.jtl> [--out-dir results/report] [--error-rate-lt 1] [
 See [ROADMAP.md](ROADMAP.md). The short version:
 
 - make the deterministic Go CLI excellent first
-- add OpenAPI/Postman/HAR import next
+- add broader import support next
 - add WebSocket/plugin automation
 - add optional AI later for generating, explaining, and improving specs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,7 +75,7 @@ Goal: make the tool valuable for backend developers, QA engineers, and CI pipeli
 Goal: let teams reuse assets they already have.
 
 - Import OpenAPI/Swagger specs into Loadwright YAML.
-- Import Postman collections.
+- Expand Postman collection import beyond the initial HTTP starter-spec support.
 - Import browser HAR files.
 - Run and report on existing `.jmx` files without conversion.
 - Add request variables, CSV data sources, auth helpers, and environment files.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,6 +91,15 @@ bin/loadwright compile /tmp/petstore-loadwright.yaml -o /tmp/petstore.jmx
 
 Demonstrates generating a starter Loadwright spec from OpenAPI 3.x.
 
+## Postman Import
+
+```bash
+bin/loadwright import postman examples/postman/checkout-api.postman_collection.json -o /tmp/checkout-loadwright.yaml
+bin/loadwright compile /tmp/checkout-loadwright.yaml -o /tmp/checkout.jmx
+```
+
+Demonstrates generating a starter Loadwright spec from a Postman Collection v2.1 file.
+
 ## CSV Users
 
 ```bash

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,13 +13,13 @@ Loadwright `v0.1.0` is intentionally focused on HTTP API load-test workflows.
 - Dockerized JMeter execution.
 - Reports from Loadwright runs or existing JMeter JTL files.
 - Initial OpenAPI 3.x import for simple HTTP APIs.
+- Initial Postman Collection v2.1 import for common HTTP API collections.
 
 ## Not Yet In Scope
 
 - Full JMeter GUI feature parity.
 - WebSocket testing.
 - JMeter plugin management.
-- Postman collection import.
 - HAR import.
 - Distributed load generation across multiple workers.
 - Historical trend storage.

--- a/docs/postman-import.md
+++ b/docs/postman-import.md
@@ -1,0 +1,34 @@
+# Postman Import
+
+Loadwright can generate a starter spec from a Postman Collection v2.1 JSON file.
+
+```bash
+bin/loadwright import postman examples/postman/checkout-api.postman_collection.json -o /tmp/checkout-loadwright.yaml
+bin/loadwright validate /tmp/checkout-loadwright.yaml
+bin/loadwright compile /tmp/checkout-loadwright.yaml -o /tmp/checkout.jmx
+```
+
+Override the target server:
+
+```bash
+bin/loadwright import postman collection.json --base-url https://staging.example.com -o loadwright.yaml
+```
+
+## What Gets Imported
+
+- Collection name becomes the spec name.
+- Collection variables become Loadwright variables.
+- Folders are included in request names.
+- Supported requests become Loadwright HTTP requests.
+- Method, path, query params, headers, and raw JSON/text bodies are imported.
+- Collection-level bearer/basic auth becomes global Loadwright auth.
+- Request-level bearer/basic auth becomes request auth.
+- Postman variables such as `{{base_url}}` remain reviewable in the YAML output.
+
+## Current Limitations
+
+- Postman Collection v2.1 JSON only.
+- Postman pre-request scripts and tests are not executed or translated.
+- Form-data, urlencoded, file, GraphQL, and advanced auth modes are reported as warnings and skipped where needed.
+- Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
+- Imported specs are starter specs and should be reviewed before CI use.

--- a/examples/postman/checkout-api.postman_collection.json
+++ b/examples/postman/checkout-api.postman_collection.json
@@ -1,0 +1,36 @@
+{
+  "info": {
+    "name": "Checkout API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {"key": "base_url", "value": "https://httpbin.org"},
+    {"key": "token", "value": "demo-token"}
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [{"key": "token", "value": "{{token}}"}]
+  },
+  "item": [
+    {
+      "name": "Status",
+      "request": {
+        "method": "GET",
+        "url": "{{base_url}}/status/200"
+      }
+    },
+    {
+      "name": "Create payload",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"hello\":\"world\"}",
+          "options": {"raw": {"language": "json"}}
+        },
+        "url": "{{base_url}}/post"
+      }
+    }
+  ]
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/devaryakjha/loadwright/internal/jmx"
 	"github.com/devaryakjha/loadwright/internal/openapi"
+	"github.com/devaryakjha/loadwright/internal/postman"
 	"github.com/devaryakjha/loadwright/internal/report"
 	"github.com/devaryakjha/loadwright/internal/runtime"
 	"github.com/devaryakjha/loadwright/internal/spec"
@@ -58,6 +59,7 @@ Usage:
   loadwright version
   loadwright init [path]
   loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
+  loadwright import postman <collection.json> [-o loadwright.yaml] [--base-url https://api.example.com]
   loadwright validate <spec.yaml> [--env-file .env.test]
   loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
   loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]
@@ -277,6 +279,8 @@ func importCommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	switch args[0] {
 	case "openapi":
 		return importOpenAPI(args[1:], stdout, stderr)
+	case "postman":
+		return importPostman(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unsupported import source: %s\n", args[0])
 		return 2
@@ -300,6 +304,31 @@ func importOpenAPI(args []string, stdout io.Writer, stderr io.Writer) int {
 	if err := spec.WriteFile(imported, output); err != nil {
 		fmt.Fprintf(stderr, "write spec failed: %v\n", err)
 		return 1
+	}
+	fmt.Fprintf(stdout, "wrote %s\n", output)
+	return 0
+}
+
+func importPostman(args []string, stdout io.Writer, stderr io.Writer) int {
+	input, output, baseURL, err := parseImportPostmanArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	result, err := postman.ImportFile(input, postman.Options{BaseURL: baseURL})
+	if err != nil {
+		fmt.Fprintf(stderr, "import failed: %v\n", err)
+		return 1
+	}
+	if output == "" {
+		output = "loadwright.yaml"
+	}
+	if err := spec.WriteFile(result.Spec, output); err != nil {
+		fmt.Fprintf(stderr, "write spec failed: %v\n", err)
+		return 1
+	}
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", warning)
 	}
 	fmt.Fprintf(stdout, "wrote %s\n", output)
 	return 0
@@ -526,6 +555,14 @@ func parseThresholdValue(flag string, raw string) (float64, error) {
 }
 
 func parseImportOpenAPIArgs(args []string) (input string, output string, baseURL string, err error) {
+	return parseImportArgs("openapi", args)
+}
+
+func parseImportPostmanArgs(args []string) (input string, output string, baseURL string, err error) {
+	return parseImportArgs("postman", args)
+}
+
+func parseImportArgs(source string, args []string) (input string, output string, baseURL string, err error) {
 	var positional []string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -553,7 +590,7 @@ func parseImportOpenAPIArgs(args []string) (input string, output string, baseURL
 		}
 	}
 	if len(positional) != 1 {
-		return "", "", "", fmt.Errorf("import openapi requires exactly one input file")
+		return "", "", "", fmt.Errorf("import %s requires exactly one input file", source)
 	}
 	return positional[0], output, baseURL, nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -144,6 +144,16 @@ func TestParseImportOpenAPIArgs(t *testing.T) {
 	}
 }
 
+func TestParseImportPostmanArgs(t *testing.T) {
+	input, output, baseURL, err := parseImportPostmanArgs([]string{"collection.json", "--out=loadwright.yaml", "--base-url", "https://staging.example.com"})
+	if err != nil {
+		t.Fatalf("parseImportPostmanArgs() error = %v", err)
+	}
+	if input != "collection.json" || output != "loadwright.yaml" || baseURL != "https://staging.example.com" {
+		t.Fatalf("unexpected args: input=%q output=%q baseURL=%q", input, output, baseURL)
+	}
+}
+
 func TestParseImportOpenAPIArgsErrors(t *testing.T) {
 	if _, _, _, err := parseImportOpenAPIArgs([]string{"openapi.yaml", "--base-url"}); err == nil {
 		t.Fatalf("expected missing base-url value error")
@@ -307,9 +317,57 @@ paths:
 	}
 }
 
+func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	collection := `{
+  "info": {"name": "CLI Import"},
+  "variable": [{"key": "base_url", "value": "https://api.example.com"}],
+  "item": [
+    {
+      "name": "Create user",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "body": {"mode": "raw", "raw": "{\"name\":\"Ada\"}", "options": {"raw": {"language": "json"}}},
+        "url": "{{base_url}}/users"
+      }
+    },
+    {
+      "name": "Upload",
+      "request": {
+        "method": "POST",
+        "body": {"mode": "formdata"},
+        "url": "{{base_url}}/upload"
+      }
+    }
+  ]
+}`
+	if err := os.WriteFile("collection.json", []byte(collection), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"import", "postman", "collection.json", "-o", "loadwright.yaml"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(import postman) code=%d stderr=%s", code, stderr.String())
+	}
+	data, err := os.ReadFile("loadwright.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "target: '{{base_url}}'") ||
+		!strings.Contains(string(data), "name: Create user") ||
+		!strings.Contains(string(data), "name: Ada") {
+		t.Fatalf("unexpected imported spec: %s", data)
+	}
+	if !strings.Contains(stderr.String(), `warning: Upload: request body mode "formdata" is not imported yet`) {
+		t.Fatalf("expected warning, got stderr=%s", stderr.String())
+	}
+}
+
 func TestRunImportRejectsUnsupportedSource(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"import", "postman", "collection.json"}, &stdout, &stderr)
+	code := Run([]string{"import", "har", "capture.har"}, &stdout, &stderr)
 	if code != 2 || !strings.Contains(stderr.String(), "unsupported import source") {
 		t.Fatalf("code=%d stderr=%s", code, stderr.String())
 	}

--- a/internal/postman/importer.go
+++ b/internal/postman/importer.go
@@ -1,0 +1,616 @@
+package postman
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/devaryakjha/loadwright/internal/spec"
+)
+
+type Options struct {
+	BaseURL string
+}
+
+type Result struct {
+	Spec     *spec.Spec
+	Warnings []string
+}
+
+type Collection struct {
+	Info      Info       `json:"info"`
+	Variables []Variable `json:"variable"`
+	Items     []Item     `json:"item"`
+	Auth      *Auth      `json:"auth"`
+}
+
+type Info struct {
+	Name string `json:"name"`
+}
+
+type Variable struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+type Item struct {
+	Name    string  `json:"name"`
+	Request Request `json:"request"`
+	Items   []Item  `json:"item"`
+}
+
+type Request struct {
+	Set     bool
+	Method  string   `json:"method"`
+	Headers []Header `json:"header"`
+	URL     URL      `json:"url"`
+	Body    Body     `json:"body"`
+	Auth    *Auth    `json:"auth"`
+}
+
+func (r *Request) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err == nil {
+		r.Set = true
+		r.Method = "GET"
+		r.URL = URL{Raw: raw}
+		return nil
+	}
+	type request Request
+	var parsed request
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	*r = Request(parsed)
+	r.Set = true
+	return nil
+}
+
+type Header struct {
+	Key      string `json:"key"`
+	Value    any    `json:"value"`
+	Disabled bool   `json:"disabled"`
+}
+
+type URL struct {
+	Raw      string       `json:"raw"`
+	Protocol string       `json:"protocol"`
+	Host     StringList   `json:"host"`
+	Path     StringList   `json:"path"`
+	Query    []QueryParam `json:"query"`
+}
+
+func (u *URL) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err == nil {
+		u.Raw = raw
+		return nil
+	}
+	type urlAlias URL
+	var parsed urlAlias
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	*u = URL(parsed)
+	return nil
+}
+
+type StringList []string
+
+func (s *StringList) UnmarshalJSON(data []byte) error {
+	var parts []string
+	if err := json.Unmarshal(data, &parts); err == nil {
+		*s = parts
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		if single == "" {
+			*s = nil
+		} else {
+			*s = []string{single}
+		}
+		return nil
+	}
+	return fmt.Errorf("expected string or string list")
+}
+
+type QueryParam struct {
+	Key      string `json:"key"`
+	Value    any    `json:"value"`
+	Disabled bool   `json:"disabled"`
+}
+
+type Body struct {
+	Mode    string      `json:"mode"`
+	Raw     string      `json:"raw"`
+	Options BodyOptions `json:"options"`
+}
+
+type BodyOptions struct {
+	Raw RawBodyOptions `json:"raw"`
+}
+
+type RawBodyOptions struct {
+	Language string `json:"language"`
+}
+
+type Auth struct {
+	Type   string     `json:"type"`
+	Bearer []KeyValue `json:"bearer"`
+	Basic  []KeyValue `json:"basic"`
+}
+
+type KeyValue struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+func ImportFile(path string, options Options) (Result, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Result{}, fmt.Errorf("read Postman collection: %w", err)
+	}
+	var collection Collection
+	if err := json.Unmarshal(data, &collection); err != nil {
+		return Result{}, fmt.Errorf("parse Postman collection JSON: %w", err)
+	}
+	return Import(collection, options)
+}
+
+func Import(collection Collection, options Options) (Result, error) {
+	name := strings.TrimSpace(collection.Info.Name)
+	if name == "" {
+		name = "postman-import"
+	}
+	loops := 1
+	errorRate := 1.0
+	p95 := 3000.0
+	out := &spec.Spec{
+		Name:      toKebab(name),
+		Target:    strings.TrimRight(strings.TrimSpace(options.BaseURL), "/"),
+		Variables: variablesFromCollection(collection.Variables),
+		Load: spec.Load{
+			Users:  1,
+			RampUp: spec.Duration{Seconds: 1, Set: true},
+			Loops:  &loops,
+		},
+		Thresholds: spec.Thresholds{
+			ErrorRateLT: &errorRate,
+			P95MsLT:     &p95,
+		},
+	}
+
+	var warnings []string
+	if collection.Auth != nil {
+		auth, warning := authFromPostman(collection.Auth)
+		if warning != "" {
+			warnings = append(warnings, warning)
+		}
+		out.Auth = auth
+	}
+
+	var firstTarget string
+	collectRequests(collection.Items, nil, collection.Auth, out, &firstTarget, &warnings)
+	if out.Target == "" {
+		out.Target = firstTarget
+	}
+	if out.Target == "" {
+		out.Target = "{{base_url}}"
+		if _, exists := out.Variables["base_url"]; !exists {
+			out.Variables["base_url"] = "https://example.com"
+		}
+		warnings = append(warnings, "no request URL target found; using {{base_url}} with https://example.com placeholder")
+	}
+	ensureTargetVariables(out.Target, out.Variables)
+	if len(out.Requests) == 0 {
+		return Result{}, fmt.Errorf("Postman collection has no supported requests")
+	}
+	if _, err := out.Resolve(nil); err != nil {
+		return Result{}, err
+	}
+	return Result{Spec: out, Warnings: dedupeWarnings(warnings)}, nil
+}
+
+func collectRequests(items []Item, folders []string, collectionAuth *Auth, out *spec.Spec, firstTarget *string, warnings *[]string) {
+	for _, item := range items {
+		name := strings.TrimSpace(item.Name)
+		nextFolders := folders
+		if len(item.Items) > 0 {
+			if name != "" {
+				nextFolders = append(append([]string{}, folders...), name)
+			}
+			collectRequests(item.Items, nextFolders, collectionAuth, out, firstTarget, warnings)
+			continue
+		}
+		if !item.Request.Set {
+			continue
+		}
+		request, target, requestWarnings, ok := requestFromPostman(item, folders, collectionAuth)
+		*warnings = append(*warnings, requestWarnings...)
+		if !ok {
+			continue
+		}
+		if *firstTarget == "" && target != "" {
+			*firstTarget = target
+		}
+		if *firstTarget != "" && target != "" && target != *firstTarget {
+			*warnings = append(*warnings, fmt.Sprintf("%s uses target %s; imported path will run against %s", request.Name, target, *firstTarget))
+		}
+		out.Requests = append(out.Requests, request)
+	}
+}
+
+func requestFromPostman(item Item, folders []string, collectionAuth *Auth) (spec.Request, string, []string, bool) {
+	var warnings []string
+	method := strings.ToUpper(strings.TrimSpace(item.Request.Method))
+	if method == "" {
+		method = "GET"
+	}
+	if !supportedMethod(method) {
+		name := requestName(item.Name, folders, method, "")
+		return spec.Request{}, "", []string{fmt.Sprintf("%s uses unsupported method %s and was skipped", name, method)}, false
+	}
+	target, requestPath, query := splitURL(item.Request.URL)
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	headers := headersFromPostman(item.Request.Headers)
+	body, bodyWarnings := bodyFromPostman(item.Request.Body, headers)
+	requestName := requestName(item.Name, folders, method, requestPath)
+	for _, warning := range bodyWarnings {
+		warnings = append(warnings, fmt.Sprintf("%s: %s", requestName, warning))
+	}
+
+	authSource := item.Request.Auth
+	if authSource == nil {
+		authSource = collectionAuth
+	}
+	requestAuth := spec.Auth{}
+	if authSource != nil && authSource != collectionAuth {
+		auth, warning := authFromPostman(authSource)
+		requestAuth = auth
+		if warning != "" {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", requestName, warning))
+		}
+	}
+
+	return spec.Request{
+		Name:    requestName,
+		Method:  method,
+		Path:    requestPath,
+		Headers: headers,
+		Query:   query,
+		Body:    body,
+		Auth:    requestAuth,
+		Expect:  spec.Expect{Status: 200},
+	}, target, warnings, true
+}
+
+func splitURL(postmanURL URL) (target string, requestPath string, query map[string]string) {
+	target, requestPath, query = splitRawURL(postmanURL.Raw)
+	if len(postmanURL.Host) > 0 {
+		host := strings.Join(postmanURL.Host, ".")
+		protocol := strings.TrimSpace(postmanURL.Protocol)
+		if protocol == "" && len(postmanURL.Host) == 1 && isVariableRef(host) {
+			target = host
+		} else {
+			if protocol == "" {
+				protocol = "https"
+			}
+			target = protocol + "://" + host
+		}
+	}
+	if len(postmanURL.Path) > 0 {
+		requestPath = "/" + strings.Join(postmanURL.Path, "/")
+	}
+	if query == nil {
+		query = map[string]string{}
+	}
+	for _, param := range postmanURL.Query {
+		if param.Disabled || strings.TrimSpace(param.Key) == "" {
+			continue
+		}
+		query[param.Key] = stringify(param.Value)
+	}
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	if !strings.HasPrefix(requestPath, "/") {
+		requestPath = "/" + requestPath
+	}
+	return strings.TrimRight(target, "/"), requestPath, query
+}
+
+func isVariableRef(value string) bool {
+	return postmanVariablePattern.MatchString(value) && postmanVariablePattern.ReplaceAllString(value, "") == ""
+}
+
+func splitRawURL(raw string) (target string, requestPath string, query map[string]string) {
+	raw = strings.TrimSpace(raw)
+	query = map[string]string{}
+	if raw == "" {
+		return "", "", query
+	}
+	if strings.Contains(raw, "://") {
+		scheme, rest, _ := strings.Cut(raw, "://")
+		host, pathQuery := splitHostPath(rest)
+		target = scheme + "://" + host
+		requestPath, query = splitPathQuery(pathQuery)
+		return strings.TrimRight(target, "/"), requestPath, query
+	}
+	if strings.HasPrefix(raw, "{{") {
+		end := strings.Index(raw, "}}")
+		if end >= 0 {
+			target = raw[:end+2]
+			requestPath, query = splitPathQuery(raw[end+2:])
+			return target, requestPath, query
+		}
+	}
+	if strings.HasPrefix(raw, "/") {
+		requestPath, query = splitPathQuery(raw)
+		return "", requestPath, query
+	}
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Host != "" {
+		target = parsed.Scheme + "://" + parsed.Host
+		requestPath = parsed.EscapedPath()
+		for key, values := range parsed.Query() {
+			if len(values) > 0 {
+				query[key] = values[0]
+			}
+		}
+		return strings.TrimRight(target, "/"), requestPath, query
+	}
+	return "", "/" + strings.TrimLeft(raw, "/"), query
+}
+
+func splitHostPath(rest string) (host string, pathQuery string) {
+	index := strings.IndexAny(rest, "/?")
+	if index < 0 {
+		return rest, ""
+	}
+	if rest[index] == '?' {
+		return rest[:index], "/" + rest[index:]
+	}
+	return rest[:index], rest[index:]
+}
+
+func splitPathQuery(pathQuery string) (string, map[string]string) {
+	query := map[string]string{}
+	if pathQuery == "" {
+		return "/", query
+	}
+	if strings.HasPrefix(pathQuery, "?") {
+		pathQuery = "/" + pathQuery
+	}
+	requestPath, rawQuery, hasQuery := strings.Cut(pathQuery, "?")
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	if hasQuery {
+		values, err := url.ParseQuery(rawQuery)
+		if err == nil {
+			for key, items := range values {
+				if len(items) > 0 {
+					query[key] = items[0]
+				}
+			}
+		}
+	}
+	cleaned := path.Clean("/" + strings.TrimLeft(requestPath, "/"))
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	return cleaned, query
+}
+
+func headersFromPostman(headers []Header) map[string]string {
+	out := map[string]string{}
+	for _, header := range headers {
+		key := strings.TrimSpace(header.Key)
+		if header.Disabled || key == "" {
+			continue
+		}
+		out[key] = stringify(header.Value)
+	}
+	return out
+}
+
+func bodyFromPostman(body Body, headers map[string]string) (any, []string) {
+	mode := strings.ToLower(strings.TrimSpace(body.Mode))
+	switch mode {
+	case "":
+		return nil, nil
+	case "raw":
+		raw := strings.TrimSpace(body.Raw)
+		if raw == "" {
+			return nil, nil
+		}
+		if shouldParseJSON(raw, body, headers) {
+			var parsed any
+			if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
+				if !hasHeader(headers, "content-type") {
+					headers["Content-Type"] = "application/json"
+				}
+				return parsed, nil
+			}
+			return raw, []string{"raw body looked like JSON but could not be parsed; imported as string"}
+		}
+		return raw, nil
+	default:
+		return nil, []string{fmt.Sprintf("request body mode %q is not imported yet", mode)}
+	}
+}
+
+func shouldParseJSON(raw string, body Body, headers map[string]string) bool {
+	if strings.EqualFold(body.Options.Raw.Language, "json") {
+		return true
+	}
+	for key, value := range headers {
+		if strings.EqualFold(key, "content-type") && strings.Contains(strings.ToLower(value), "json") {
+			return true
+		}
+	}
+	return strings.HasPrefix(raw, "{") || strings.HasPrefix(raw, "[")
+}
+
+func authFromPostman(auth *Auth) (spec.Auth, string) {
+	if auth == nil {
+		return spec.Auth{}, ""
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "":
+		return spec.Auth{}, ""
+	case "bearer":
+		token := keyValue(auth.Bearer, "token")
+		if token == "" {
+			return spec.Auth{}, "bearer auth is missing token and was skipped"
+		}
+		return spec.Auth{Type: "bearer", Token: token}, ""
+	case "basic":
+		username := keyValue(auth.Basic, "username")
+		password := keyValue(auth.Basic, "password")
+		if username == "" {
+			return spec.Auth{}, "basic auth is missing username and was skipped"
+		}
+		return spec.Auth{Type: "basic", Username: username, Password: password}, ""
+	default:
+		return spec.Auth{}, fmt.Sprintf("auth type %q is not imported yet", auth.Type)
+	}
+}
+
+func keyValue(values []KeyValue, key string) string {
+	for _, value := range values {
+		if strings.EqualFold(value.Key, key) {
+			return stringify(value.Value)
+		}
+	}
+	return ""
+}
+
+func variablesFromCollection(values []Variable) map[string]string {
+	out := map[string]string{}
+	for _, variable := range values {
+		key := strings.TrimSpace(variable.Key)
+		if key == "" {
+			continue
+		}
+		out[key] = stringify(variable.Value)
+	}
+	return out
+}
+
+var postmanVariablePattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
+func ensureTargetVariables(target string, variables map[string]string) {
+	matches := postmanVariablePattern.FindAllStringSubmatch(target, -1)
+	for _, match := range matches {
+		key := match[1]
+		if _, exists := variables[key]; exists {
+			continue
+		}
+		if target == match[0] {
+			variables[key] = "https://example.com"
+		} else {
+			variables[key] = "example.com"
+		}
+	}
+}
+
+func requestName(itemName string, folders []string, method string, requestPath string) string {
+	parts := make([]string, 0, len(folders)+1)
+	for _, folder := range folders {
+		if strings.TrimSpace(folder) != "" {
+			parts = append(parts, strings.TrimSpace(folder))
+		}
+	}
+	if strings.TrimSpace(itemName) != "" {
+		parts = append(parts, strings.TrimSpace(itemName))
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, " / ")
+	}
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	return method + " " + requestPath
+}
+
+func supportedMethod(method string) bool {
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasHeader(headers map[string]string, name string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringify(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case float64:
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%d", int64(typed))
+		}
+		return fmt.Sprintf("%v", typed)
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func toKebab(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	previousDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			previousDash = false
+			continue
+		}
+		if !previousDash && builder.Len() > 0 {
+			builder.WriteByte('-')
+			previousDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func dedupeWarnings(warnings []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, warning := range warnings {
+		warning = strings.TrimSpace(warning)
+		if warning == "" || seen[warning] {
+			continue
+		}
+		seen[warning] = true
+		out = append(out, warning)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/postman/importer_test.go
+++ b/internal/postman/importer_test.go
@@ -1,0 +1,228 @@
+package postman
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportCollectionBasics(t *testing.T) {
+	result, err := ImportFile(writeCollection(t, postmanCollection), Options{})
+	if err != nil {
+		t.Fatalf("ImportFile() error = %v", err)
+	}
+	imported := result.Spec
+	if imported.Name != "checkout-api" {
+		t.Fatalf("name = %q", imported.Name)
+	}
+	if imported.Target != "{{base_url}}" {
+		t.Fatalf("target = %q", imported.Target)
+	}
+	if imported.Variables["base_url"] != "https://api.example.com" {
+		t.Fatalf("base_url variable = %q", imported.Variables["base_url"])
+	}
+	if imported.Auth.Type != "bearer" || imported.Auth.Token != "{{token}}" {
+		t.Fatalf("auth = %+v", imported.Auth)
+	}
+	if len(imported.Requests) != 2 {
+		t.Fatalf("requests = %d", len(imported.Requests))
+	}
+	list := imported.Requests[0]
+	if list.Name != "Users / List users" || list.Method != "GET" || list.Path != "/v1/users" {
+		t.Fatalf("unexpected list request: %+v", list)
+	}
+	if list.Query["limit"] != "10" || list.Query["active"] != "true" {
+		t.Fatalf("query = %+v", list.Query)
+	}
+	if list.Headers["X-Trace"] != "{{trace_id}}" {
+		t.Fatalf("headers = %+v", list.Headers)
+	}
+	create := imported.Requests[1]
+	if create.Method != "POST" || create.Path != "/v1/users" {
+		t.Fatalf("unexpected create request: %+v", create)
+	}
+	body := create.Body.(map[string]any)
+	if body["name"] != "Ada" || body["role"] != "admin" {
+		t.Fatalf("body = %+v", body)
+	}
+	if create.Headers["Content-Type"] != "application/json" {
+		t.Fatalf("headers = %+v", create.Headers)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+}
+
+func TestImportBaseURLOverrideAndStringRequest(t *testing.T) {
+	result, err := Import(Collection{
+		Info: Info{Name: "String URL"},
+		Items: []Item{{
+			Name: "Health",
+			Request: Request{
+				Set:    true,
+				Method: "GET",
+				URL:    URL{Raw: "https://prod.example.com/health?ready=true"},
+			},
+		}},
+	}, Options{BaseURL: "https://staging.example.com"})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if result.Spec.Target != "https://staging.example.com" {
+		t.Fatalf("target = %q", result.Spec.Target)
+	}
+	request := result.Spec.Requests[0]
+	if request.Path != "/health" || request.Query["ready"] != "true" {
+		t.Fatalf("request = %+v", request)
+	}
+}
+
+func TestImportRequestLevelBasicAuth(t *testing.T) {
+	result, err := Import(Collection{
+		Info: Info{Name: "Auth"},
+		Items: []Item{{
+			Name: "Secure",
+			Request: Request{
+				Set:    true,
+				Method: "GET",
+				URL:    URL{Raw: "https://api.example.com/secure"},
+				Auth: &Auth{Type: "basic", Basic: []KeyValue{
+					{Key: "username", Value: "{{username}}"},
+					{Key: "password", Value: "{{password}}"},
+				}},
+			},
+		}},
+		Variables: []Variable{
+			{Key: "username", Value: "demo"},
+			{Key: "password", Value: "secret"},
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	auth := result.Spec.Requests[0].Auth
+	if auth.Type != "basic" || auth.Username != "{{username}}" || auth.Password != "{{password}}" {
+		t.Fatalf("auth = %+v", auth)
+	}
+}
+
+func TestImportWarnsForUnsupportedFeatures(t *testing.T) {
+	result, err := Import(Collection{
+		Info: Info{Name: "Unsupported"},
+		Auth: &Auth{Type: "digest"},
+		Items: []Item{
+			{
+				Name: "GraphQL",
+				Request: Request{
+					Set:    true,
+					Method: "POST",
+					URL:    URL{Raw: "https://api.example.com/graphql"},
+					Body:   Body{Mode: "graphql"},
+				},
+			},
+			{
+				Name: "Trace",
+				Request: Request{
+					Set:    true,
+					Method: "TRACE",
+					URL:    URL{Raw: "https://api.example.com/trace"},
+				},
+			},
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	joined := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(joined, `auth type "digest" is not imported yet`) ||
+		!strings.Contains(joined, `request body mode "graphql" is not imported yet`) ||
+		!strings.Contains(joined, "Trace uses unsupported method TRACE and was skipped") {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+	if len(result.Spec.Requests) != 1 || result.Spec.Requests[0].Name != "GraphQL" {
+		t.Fatalf("requests = %+v", result.Spec.Requests)
+	}
+}
+
+func TestImportRejectsNoSupportedRequests(t *testing.T) {
+	_, err := Import(Collection{
+		Info: Info{Name: "Empty"},
+		Items: []Item{{
+			Name: "Trace",
+			Request: Request{
+				Set:    true,
+				Method: "TRACE",
+				URL:    URL{Raw: "https://api.example.com/trace"},
+			},
+		}},
+	}, Options{})
+	if err == nil {
+		t.Fatalf("expected no supported requests error")
+	}
+}
+
+func writeCollection(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "collection.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const postmanCollection = `{
+  "info": {
+    "name": "Checkout API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {"key": "base_url", "value": "https://api.example.com"},
+    {"key": "token", "value": "demo-token"},
+    {"key": "trace_id", "value": "trace-123"}
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [{"key": "token", "value": "{{token}}"}]
+  },
+  "item": [
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "List users",
+          "request": {
+            "method": "GET",
+            "header": [
+              {"key": "X-Trace", "value": "{{trace_id}}"},
+              {"key": "X-Disabled", "value": "nope", "disabled": true}
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/users?limit=10",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "users"],
+              "query": [
+                {"key": "limit", "value": "10"},
+                {"key": "active", "value": true}
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create user",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"Ada\",\"role\":\"admin\"}",
+              "options": {"raw": {"language": "json"}}
+            },
+            "url": "{{base_url}}/v1/users"
+          }
+        }
+      ]
+    }
+  ]
+}`


### PR DESCRIPTION
## Summary

Closes #1.

Adds initial Postman Collection v2.1 import support so users can bootstrap Loadwright YAML from existing Postman API collections.

## What Changed

- Adds `loadwright import postman <collection.json> [-o loadwright.yaml] [--base-url ...]`.
- Imports collection variables, folders, request names, methods, URLs, query params, headers, raw JSON/text bodies, and simple bearer/basic auth.
- Emits warnings for unsupported or lossy Postman features.
- Adds Postman importer unit coverage, CLI coverage, docs, and an example collection.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
- `bin/loadwright import postman examples/postman/checkout-api.postman_collection.json -o /tmp/loadwright-postman-smoke.yaml`
- `bin/loadwright validate /tmp/loadwright-postman-smoke.yaml`
- `bin/loadwright compile /tmp/loadwright-postman-smoke.yaml -o /tmp/loadwright-postman-smoke.jmx`

## Notes

This is intentionally starter-spec import, not full Postman runtime compatibility. Postman scripts/tests, form-data, urlencoded bodies, files, GraphQL bodies, and advanced auth modes remain out of scope for this first slice.
