### PR TITLE
Fix Jaykumar mailmap alias

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,3 @@
 Jaykumar Gori <38314988+jaykumargori@users.noreply.github.com> Manish Bhanushali <manish.bhanushali@twinciti.com>
+Jaykumar Gori <38314988+jaykumargori@users.noreply.github.com> Manish Bhanushali <jaybhanushali669@gmail.com>
 Jaykumar Gori <38314988+jaykumargori@users.noreply.github.com> Jaykumar Gori <jaybhanushali669@gmail.com>


### PR DESCRIPTION
## Summary

Closes #3.

Adds the missing mailmap alias for commits authored as `Manish Bhanushali <jaybhanushali669@gmail.com>` so Git mailmap-aware views group them under Jaykumar Gori's GitHub noreply identity.

## Verification

- `git diff --check`
- `git log --format='%h%x09%aN%x09%aE%x09%s' --all | rg 'Jaykumar|Manish|jaybhanushali|twinciti'`
- `git shortlog -sne --all`
