### PR TITLE
Add HAR import support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add public project-status badges and initial prototype attribution.
 - Add mailmap attribution for Jaykumar Gori's earlier commit identities.
 - Add initial Postman Collection v2.1 import support.
+- Add initial HAR 1.2 import support.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is not a new load-testing engine. It is a small automation layer that keeps J
 
 Loadwright is at `v0.1.0`. It is usable for HTTP API load-test workflows and CI smoke/performance checks, but the public API and YAML spec may still evolve before `v1.0.0`.
 
-The current release is intentionally focused: HTTP requests, Dockerized JMeter execution, OpenAPI bootstrapping, CSV data, thresholds, and reports. WebSocket support, plugin management, Postman/HAR import, distributed runners, and AI-assisted workflows are planned later.
+The current development scope is intentionally focused: HTTP requests, Dockerized JMeter execution, OpenAPI/Postman/HAR bootstrapping, CSV data, thresholds, and reports. WebSocket support, plugin management, distributed runners, and AI-assisted workflows are planned later.
 
 ## Why This Exists
 
@@ -29,6 +29,7 @@ Use Loadwright when you want:
 - CI pass/fail thresholds
 - OpenAPI-to-spec bootstrapping for simple API tests
 - Postman-collection-to-spec bootstrapping for common API workflows
+- HAR-to-spec bootstrapping from browser/API traffic captures
 - future optional AI assistance without depending on AI for normal runs
 
 Current `v0.1.0` scope: HTTP API load tests. See [docs/limitations.md](docs/limitations.md) for known limits.
@@ -102,6 +103,7 @@ More docs:
 - [Examples](docs/examples.md)
 - [OpenAPI import](docs/openapi-import.md)
 - [Postman import](docs/postman-import.md)
+- [HAR import](docs/har-import.md)
 - [Data sources](docs/data-sources.md)
 - [CI](docs/ci.md)
 - [Reports](docs/reports.md)
@@ -118,6 +120,7 @@ loadwright version
 loadwright init [path]
 loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
 loadwright import postman <collection.json> [-o loadwright.yaml] [--base-url https://api.example.com]
+loadwright import har <capture.har> [-o loadwright.yaml] [--base-url https://api.example.com]
 loadwright validate <spec.yaml> [--env-file .env.test]
 loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
 loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Goal: let teams reuse assets they already have.
 
 - Import OpenAPI/Swagger specs into Loadwright YAML.
 - Expand Postman collection import beyond the initial HTTP starter-spec support.
-- Import browser HAR files.
+- Expand browser HAR import beyond the initial HTTP starter-spec support.
 - Run and report on existing `.jmx` files without conversion.
 - Add request variables, CSV data sources, auth helpers, and environment files.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -100,6 +100,15 @@ bin/loadwright compile /tmp/checkout-loadwright.yaml -o /tmp/checkout.jmx
 
 Demonstrates generating a starter Loadwright spec from a Postman Collection v2.1 file.
 
+## HAR Import
+
+```bash
+bin/loadwright import har examples/har/checkout.har -o /tmp/checkout-har-loadwright.yaml
+bin/loadwright compile /tmp/checkout-har-loadwright.yaml -o /tmp/checkout-har.jmx
+```
+
+Demonstrates generating a starter Loadwright spec from a HAR 1.2 traffic capture.
+
 ## CSV Users
 
 ```bash

--- a/docs/har-import.md
+++ b/docs/har-import.md
@@ -1,0 +1,33 @@
+# HAR Import
+
+Loadwright can generate a starter spec from a HAR 1.2 JSON file exported from a browser or API debugging tool.
+
+```bash
+bin/loadwright import har examples/har/checkout.har -o /tmp/checkout-har-loadwright.yaml
+bin/loadwright validate /tmp/checkout-har-loadwright.yaml
+bin/loadwright compile /tmp/checkout-har-loadwright.yaml -o /tmp/checkout-har.jmx
+```
+
+Override the target server:
+
+```bash
+bin/loadwright import har capture.har --base-url https://staging.example.com -o loadwright.yaml
+```
+
+## What Gets Imported
+
+- The HAR filename becomes the spec name.
+- The first request origin becomes `target` unless `--base-url` is provided.
+- Supported requests become Loadwright HTTP requests.
+- Method, path, query params, headers, and JSON/text request bodies are imported.
+- Form params are imported as a flat starter body with a warning.
+- Unsupported or lossy capture details are reported as warnings.
+
+## Current Limitations
+
+- HAR 1.2 JSON only.
+- Browser replay semantics are not reproduced.
+- Cookies are not imported.
+- File uploads and encoded/binary request bodies are skipped with warnings.
+- Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
+- Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,13 +14,13 @@ Loadwright `v0.1.0` is intentionally focused on HTTP API load-test workflows.
 - Reports from Loadwright runs or existing JMeter JTL files.
 - Initial OpenAPI 3.x import for simple HTTP APIs.
 - Initial Postman Collection v2.1 import for common HTTP API collections.
+- Initial HAR 1.2 import for common HTTP API traffic captures.
 
 ## Not Yet In Scope
 
 - Full JMeter GUI feature parity.
 - WebSocket testing.
 - JMeter plugin management.
-- HAR import.
 - Distributed load generation across multiple workers.
 - Historical trend storage.
 - Browser-level performance testing.

--- a/examples/har/checkout.har
+++ b/examples/har/checkout.har
@@ -1,0 +1,40 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Loadwright example",
+      "version": "1.0"
+    },
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/status/200",
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "application/json"
+            }
+          ],
+          "queryString": []
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://httpbin.org/post",
+          "headers": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"hello\":\"world\"}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devaryakjha/loadwright/internal/har"
 	"github.com/devaryakjha/loadwright/internal/jmx"
 	"github.com/devaryakjha/loadwright/internal/openapi"
 	"github.com/devaryakjha/loadwright/internal/postman"
@@ -60,6 +61,7 @@ Usage:
   loadwright init [path]
   loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
   loadwright import postman <collection.json> [-o loadwright.yaml] [--base-url https://api.example.com]
+  loadwright import har <capture.har> [-o loadwright.yaml] [--base-url https://api.example.com]
   loadwright validate <spec.yaml> [--env-file .env.test]
   loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
   loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]
@@ -281,6 +283,8 @@ func importCommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		return importOpenAPI(args[1:], stdout, stderr)
 	case "postman":
 		return importPostman(args[1:], stdout, stderr)
+	case "har":
+		return importHAR(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unsupported import source: %s\n", args[0])
 		return 2
@@ -316,6 +320,31 @@ func importPostman(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 2
 	}
 	result, err := postman.ImportFile(input, postman.Options{BaseURL: baseURL})
+	if err != nil {
+		fmt.Fprintf(stderr, "import failed: %v\n", err)
+		return 1
+	}
+	if output == "" {
+		output = "loadwright.yaml"
+	}
+	if err := spec.WriteFile(result.Spec, output); err != nil {
+		fmt.Fprintf(stderr, "write spec failed: %v\n", err)
+		return 1
+	}
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", warning)
+	}
+	fmt.Fprintf(stdout, "wrote %s\n", output)
+	return 0
+}
+
+func importHAR(args []string, stdout io.Writer, stderr io.Writer) int {
+	input, output, baseURL, err := parseImportHARArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	result, err := har.ImportFile(input, har.Options{BaseURL: baseURL})
 	if err != nil {
 		fmt.Fprintf(stderr, "import failed: %v\n", err)
 		return 1
@@ -560,6 +589,10 @@ func parseImportOpenAPIArgs(args []string) (input string, output string, baseURL
 
 func parseImportPostmanArgs(args []string) (input string, output string, baseURL string, err error) {
 	return parseImportArgs("postman", args)
+}
+
+func parseImportHARArgs(args []string) (input string, output string, baseURL string, err error) {
+	return parseImportArgs("har", args)
 }
 
 func parseImportArgs(source string, args []string) (input string, output string, baseURL string, err error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -154,6 +154,16 @@ func TestParseImportPostmanArgs(t *testing.T) {
 	}
 }
 
+func TestParseImportHARArgs(t *testing.T) {
+	input, output, baseURL, err := parseImportHARArgs([]string{"capture.har", "-o", "loadwright.yaml", "--base-url=https://staging.example.com"})
+	if err != nil {
+		t.Fatalf("parseImportHARArgs() error = %v", err)
+	}
+	if input != "capture.har" || output != "loadwright.yaml" || baseURL != "https://staging.example.com" {
+		t.Fatalf("unexpected args: input=%q output=%q baseURL=%q", input, output, baseURL)
+	}
+}
+
 func TestParseImportOpenAPIArgsErrors(t *testing.T) {
 	if _, _, _, err := parseImportOpenAPIArgs([]string{"openapi.yaml", "--base-url"}); err == nil {
 		t.Fatalf("expected missing base-url value error")
@@ -365,9 +375,66 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
 	}
 }
 
+func TestRunImportHARCreatesSpecAndWarnings(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	capture := `{
+  "log": {
+    "version": "1.2",
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://api.example.com/users?limit=10",
+          "headers": [{"name": "Accept", "value": "application/json"}],
+          "queryString": [{"name": "active", "value": true}]
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://api.example.com/users",
+          "headers": [{"name": "Content-Type", "value": "application/json"}],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"name\":\"Ada\"}"
+          }
+        }
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://other.example.com/health"
+        }
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile("capture.har", []byte(capture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"import", "har", "capture.har", "-o", "loadwright.yaml"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(import har) code=%d stderr=%s", code, stderr.String())
+	}
+	data, err := os.ReadFile("loadwright.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "target: https://api.example.com") ||
+		!strings.Contains(string(data), "name: GET /users") ||
+		!strings.Contains(string(data), "name: Ada") {
+		t.Fatalf("unexpected imported spec: %s", data)
+	}
+	if !strings.Contains(stderr.String(), "warning: GET /health uses target https://other.example.com; imported path will run against https://api.example.com") {
+		t.Fatalf("expected warning, got stderr=%s", stderr.String())
+	}
+}
+
 func TestRunImportRejectsUnsupportedSource(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"import", "har", "capture.har"}, &stdout, &stderr)
+	code := Run([]string{"import", "insomnia", "export.json"}, &stdout, &stderr)
 	if code != 2 || !strings.Contains(stderr.String(), "unsupported import source") {
 		t.Fatalf("code=%d stderr=%s", code, stderr.String())
 	}

--- a/internal/har/importer.go
+++ b/internal/har/importer.go
@@ -1,0 +1,355 @@
+package har
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/devaryakjha/loadwright/internal/spec"
+)
+
+type Options struct {
+	BaseURL string
+	Name    string
+}
+
+type Result struct {
+	Spec     *spec.Spec
+	Warnings []string
+}
+
+type Archive struct {
+	Log Log `json:"log"`
+}
+
+type Log struct {
+	Version string  `json:"version"`
+	Entries []Entry `json:"entries"`
+}
+
+type Entry struct {
+	Request Request `json:"request"`
+}
+
+type Request struct {
+	Method      string      `json:"method"`
+	URL         string      `json:"url"`
+	Headers     []NameValue `json:"headers"`
+	QueryString []NameValue `json:"queryString"`
+	Cookies     []NameValue `json:"cookies"`
+	PostData    *PostData   `json:"postData"`
+}
+
+type NameValue struct {
+	Name  string `json:"name"`
+	Value any    `json:"value"`
+}
+
+type PostData struct {
+	MimeType string      `json:"mimeType"`
+	Text     string      `json:"text"`
+	Encoding string      `json:"encoding"`
+	Params   []PostParam `json:"params"`
+}
+
+type PostParam struct {
+	Name        string `json:"name"`
+	Value       any    `json:"value"`
+	FileName    string `json:"fileName"`
+	ContentType string `json:"contentType"`
+}
+
+func ImportFile(path string, options Options) (Result, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Result{}, fmt.Errorf("read HAR file: %w", err)
+	}
+	var archive Archive
+	if err := json.Unmarshal(data, &archive); err != nil {
+		return Result{}, fmt.Errorf("parse HAR JSON: %w", err)
+	}
+	if strings.TrimSpace(options.Name) == "" {
+		options.Name = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	return Import(archive, options)
+}
+
+func Import(archive Archive, options Options) (Result, error) {
+	name := strings.TrimSpace(options.Name)
+	if name == "" {
+		name = "har-import"
+	}
+	loops := 1
+	errorRate := 1.0
+	p95 := 3000.0
+	out := &spec.Spec{
+		Name:      toKebab(name),
+		Target:    strings.TrimRight(strings.TrimSpace(options.BaseURL), "/"),
+		Variables: map[string]string{},
+		Load: spec.Load{
+			Users:  1,
+			RampUp: spec.Duration{Seconds: 1, Set: true},
+			Loops:  &loops,
+		},
+		Thresholds: spec.Thresholds{
+			ErrorRateLT: &errorRate,
+			P95MsLT:     &p95,
+		},
+	}
+
+	var warnings []string
+	var firstTarget string
+	for index, entry := range archive.Log.Entries {
+		request, target, requestWarnings, ok := requestFromHAR(index, entry.Request)
+		warnings = append(warnings, requestWarnings...)
+		if !ok {
+			continue
+		}
+		if firstTarget == "" && target != "" {
+			firstTarget = target
+		}
+		if out.Target == "" && target != "" && firstTarget != "" && target != firstTarget {
+			warnings = append(warnings, fmt.Sprintf("%s uses target %s; imported path will run against %s", request.Name, target, firstTarget))
+		}
+		if out.Target != "" && target != "" && target != out.Target {
+			warnings = append(warnings, fmt.Sprintf("%s uses target %s; imported path will run against %s", request.Name, target, out.Target))
+		}
+		out.Requests = append(out.Requests, request)
+	}
+	if len(out.Requests) == 0 {
+		return Result{}, fmt.Errorf("HAR file has no supported requests")
+	}
+	if out.Target == "" {
+		out.Target = firstTarget
+	}
+	if out.Target == "" {
+		return Result{}, fmt.Errorf("HAR file has no absolute request URLs")
+	}
+	if _, err := out.Resolve(nil); err != nil {
+		return Result{}, err
+	}
+	return Result{Spec: out, Warnings: dedupeWarnings(warnings)}, nil
+}
+
+func requestFromHAR(index int, harRequest Request) (spec.Request, string, []string, bool) {
+	var warnings []string
+	method := strings.ToUpper(strings.TrimSpace(harRequest.Method))
+	if method == "" {
+		method = "GET"
+	}
+	name := requestName(method, harRequest.URL)
+	if !supportedMethod(method) {
+		return spec.Request{}, "", []string{fmt.Sprintf("%s uses unsupported method %s and was skipped", name, method)}, false
+	}
+	target, requestPath, query, err := splitURL(harRequest.URL)
+	if err != nil {
+		return spec.Request{}, "", []string{fmt.Sprintf("entry %d has unsupported URL %q and was skipped", index, harRequest.URL)}, false
+	}
+	for _, item := range harRequest.QueryString {
+		key := strings.TrimSpace(item.Name)
+		if key == "" {
+			continue
+		}
+		query[key] = stringify(item.Value)
+	}
+	headers, headerWarnings := headersFromHAR(name, harRequest.Headers)
+	warnings = append(warnings, headerWarnings...)
+	if len(harRequest.Cookies) > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s has cookies; cookies are not imported", name))
+	}
+	body, bodyWarnings := bodyFromHAR(name, harRequest.PostData, headers)
+	warnings = append(warnings, bodyWarnings...)
+
+	return spec.Request{
+		Name:    name,
+		Method:  method,
+		Path:    requestPath,
+		Headers: headers,
+		Query:   query,
+		Body:    body,
+		Expect:  spec.Expect{Status: 200},
+	}, target, warnings, true
+}
+
+func splitURL(raw string) (target string, requestPath string, query map[string]string, err error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", nil, fmt.Errorf("URL must be absolute")
+	}
+	target = parsed.Scheme + "://" + parsed.Host
+	requestPath = parsed.EscapedPath()
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	cleaned := path.Clean("/" + strings.TrimLeft(requestPath, "/"))
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	query = map[string]string{}
+	for key, values := range parsed.Query() {
+		if len(values) > 0 {
+			query[key] = values[0]
+		}
+	}
+	return strings.TrimRight(target, "/"), cleaned, query, nil
+}
+
+func headersFromHAR(requestName string, headers []NameValue) (map[string]string, []string) {
+	out := map[string]string{}
+	var warnings []string
+	for _, header := range headers {
+		key := strings.TrimSpace(header.Name)
+		if key == "" {
+			continue
+		}
+		switch {
+		case strings.EqualFold(key, "host"),
+			strings.EqualFold(key, "content-length"),
+			strings.EqualFold(key, "cookie"):
+			if strings.EqualFold(key, "cookie") {
+				warnings = append(warnings, fmt.Sprintf("%s has cookie header; cookies are not imported", requestName))
+			}
+			continue
+		case strings.EqualFold(key, "authorization"):
+			warnings = append(warnings, fmt.Sprintf("%s has authorization header; imported as a static header", requestName))
+		}
+		out[key] = stringify(header.Value)
+	}
+	return out, warnings
+}
+
+func bodyFromHAR(requestName string, postData *PostData, headers map[string]string) (any, []string) {
+	if postData == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(postData.Encoding) != "" && !strings.EqualFold(postData.Encoding, "utf-8") {
+		return nil, []string{fmt.Sprintf("%s request body uses %s encoding and was skipped", requestName, postData.Encoding)}
+	}
+	if len(postData.Params) > 0 {
+		for _, param := range postData.Params {
+			if strings.TrimSpace(param.FileName) != "" {
+				return nil, []string{fmt.Sprintf("%s has file upload form data; body was skipped", requestName)}
+			}
+		}
+		return paramsBody(postData.Params), []string{fmt.Sprintf("%s has form params; imported as a flat object starter body", requestName)}
+	}
+	text := strings.TrimSpace(postData.Text)
+	if text == "" {
+		return nil, nil
+	}
+	if shouldParseJSON(text, postData.MimeType, headers) {
+		var parsed any
+		if err := json.Unmarshal([]byte(text), &parsed); err == nil {
+			if !hasHeader(headers, "content-type") {
+				headers["Content-Type"] = "application/json"
+			}
+			return parsed, nil
+		}
+		return text, []string{fmt.Sprintf("%s body looked like JSON but could not be parsed; imported as string", requestName)}
+	}
+	return text, nil
+}
+
+func paramsBody(params []PostParam) map[string]any {
+	out := map[string]any{}
+	for _, param := range params {
+		key := strings.TrimSpace(param.Name)
+		if key == "" {
+			continue
+		}
+		out[key] = stringify(param.Value)
+	}
+	return out
+}
+
+func shouldParseJSON(text string, mimeType string, headers map[string]string) bool {
+	if strings.Contains(strings.ToLower(mimeType), "json") {
+		return true
+	}
+	for key, value := range headers {
+		if strings.EqualFold(key, "content-type") && strings.Contains(strings.ToLower(value), "json") {
+			return true
+		}
+	}
+	return strings.HasPrefix(text, "{") || strings.HasPrefix(text, "[")
+}
+
+func requestName(method string, rawURL string) string {
+	_, requestPath, _, err := splitURL(rawURL)
+	if err != nil || requestPath == "" {
+		requestPath = "/"
+	}
+	return method + " " + requestPath
+}
+
+func supportedMethod(method string) bool {
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasHeader(headers map[string]string, name string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringify(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case float64:
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%d", int64(typed))
+		}
+		return fmt.Sprintf("%v", typed)
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func toKebab(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	previousDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			previousDash = false
+			continue
+		}
+		if !previousDash && builder.Len() > 0 {
+			builder.WriteByte('-')
+			previousDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func dedupeWarnings(warnings []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, warning := range warnings {
+		warning = strings.TrimSpace(warning)
+		if warning == "" || seen[warning] {
+			continue
+		}
+		seen[warning] = true
+		out = append(out, warning)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/har/importer_test.go
+++ b/internal/har/importer_test.go
@@ -1,0 +1,180 @@
+package har
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportHARBasics(t *testing.T) {
+	result, err := ImportFile(writeHAR(t, checkoutHAR), Options{})
+	if err != nil {
+		t.Fatalf("ImportFile() error = %v", err)
+	}
+	imported := result.Spec
+	if imported.Name != "checkout" {
+		t.Fatalf("name = %q", imported.Name)
+	}
+	if imported.Target != "https://api.example.com" {
+		t.Fatalf("target = %q", imported.Target)
+	}
+	if len(imported.Requests) != 2 {
+		t.Fatalf("requests = %d", len(imported.Requests))
+	}
+	list := imported.Requests[0]
+	if list.Name != "GET /v1/users" || list.Method != "GET" || list.Path != "/v1/users" {
+		t.Fatalf("unexpected list request: %+v", list)
+	}
+	if list.Query["limit"] != "10" || list.Query["active"] != "true" {
+		t.Fatalf("query = %+v", list.Query)
+	}
+	if list.Headers["Accept"] != "application/json" {
+		t.Fatalf("headers = %+v", list.Headers)
+	}
+	create := imported.Requests[1]
+	if create.Name != "POST /v1/users" || create.Method != "POST" || create.Path != "/v1/users" {
+		t.Fatalf("unexpected create request: %+v", create)
+	}
+	body := create.Body.(map[string]any)
+	if body["name"] != "Ada" || body["role"] != "admin" {
+		t.Fatalf("body = %+v", body)
+	}
+	if create.Headers["Content-Type"] != "application/json" {
+		t.Fatalf("headers = %+v", create.Headers)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+}
+
+func TestImportBaseURLOverrideAndWarnings(t *testing.T) {
+	result, err := Import(Archive{Log: Log{Version: "1.2", Entries: []Entry{
+		{Request: Request{
+			Method: "GET",
+			URL:    "https://prod.example.com/health",
+			Headers: []NameValue{
+				{Name: "Cookie", Value: "session=secret"},
+				{Name: "Authorization", Value: "Bearer token"},
+			},
+			Cookies: []NameValue{{Name: "session", Value: "secret"}},
+		}},
+		{Request: Request{
+			Method: "POST",
+			URL:    "https://other.example.com/upload",
+			PostData: &PostData{
+				Encoding: "base64",
+				Text:     "AAAA",
+			},
+		}},
+	}}}, Options{Name: "Warnings", BaseURL: "https://staging.example.com"})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if result.Spec.Target != "https://staging.example.com" {
+		t.Fatalf("target = %q", result.Spec.Target)
+	}
+	joined := strings.Join(result.Warnings, "\n")
+	for _, expected := range []string{
+		"GET /health has authorization header; imported as a static header",
+		"GET /health has cookie header; cookies are not imported",
+		"GET /health has cookies; cookies are not imported",
+		"POST /upload request body uses base64 encoding and was skipped",
+		"POST /upload uses target https://other.example.com; imported path will run against https://staging.example.com",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("missing warning %q in %+v", expected, result.Warnings)
+		}
+	}
+	if _, ok := result.Spec.Requests[0].Headers["Cookie"]; ok {
+		t.Fatalf("cookie header should not be imported: %+v", result.Spec.Requests[0].Headers)
+	}
+}
+
+func TestImportFormParamsAsStarterBody(t *testing.T) {
+	result, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
+		Method: "POST",
+		URL:    "https://api.example.com/login",
+		PostData: &PostData{Params: []PostParam{
+			{Name: "username", Value: "demo"},
+			{Name: "password", Value: "secret"},
+		}},
+	}}}}}, Options{Name: "Form"})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	body := result.Spec.Requests[0].Body.(map[string]any)
+	if body["username"] != "demo" || body["password"] != "secret" {
+		t.Fatalf("body = %+v", body)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "POST /login has form params; imported as a flat object starter body") {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+}
+
+func TestImportRejectsNoSupportedRequests(t *testing.T) {
+	_, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
+		Method: "TRACE",
+		URL:    "https://api.example.com/trace",
+	}}}}}, Options{Name: "Empty"})
+	if err == nil {
+		t.Fatalf("expected no supported requests error")
+	}
+}
+
+func TestImportRejectsRelativeURLs(t *testing.T) {
+	_, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
+		Method: "GET",
+		URL:    "/relative",
+	}}}}}, Options{Name: "Relative"})
+	if err == nil {
+		t.Fatalf("expected no absolute URL error")
+	}
+}
+
+func writeHAR(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkout.har")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const checkoutHAR = `{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Loadwright test", "version": "1.0"},
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://api.example.com/v1/users?limit=10",
+          "headers": [
+            {"name": "Accept", "value": "application/json"},
+            {"name": "Host", "value": "api.example.com"}
+          ],
+          "queryString": [
+            {"name": "limit", "value": "10"},
+            {"name": "active", "value": true}
+          ]
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://api.example.com/v1/users",
+          "headers": [
+            {"name": "Content-Type", "value": "application/json"},
+            {"name": "Content-Length", "value": "29"}
+          ],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"name\":\"Ada\",\"role\":\"admin\"}"
+          }
+        }
+      }
+    ]
+  }
+}`


### PR DESCRIPTION
## Summary

Closes #5.

Adds initial HAR 1.2 import support so users can bootstrap Loadwright YAML from browser or API traffic captures.

## What Changed

- Adds `loadwright import har <capture.har> [-o loadwright.yaml] [--base-url ...]`.
- Imports HTTP method, URL path, query params, headers, JSON/text request bodies, and simple form params.
- Uses the first request origin as the target unless `--base-url` is provided.
- Emits warnings for multiple targets, cookies, static authorization headers, encoded bodies, file uploads, unsupported methods, and other lossy import cases.
- Adds HAR importer unit coverage, CLI coverage, docs, and an example HAR capture.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
- `bin/loadwright import har examples/har/checkout.har -o /tmp/loadwright-har-smoke.yaml`
- `bin/loadwright validate /tmp/loadwright-har-smoke.yaml`
- `bin/loadwright compile /tmp/loadwright-har-smoke.yaml -o /tmp/loadwright-har-smoke.jmx`

## Notes

This is intentionally starter-spec import, not full browser replay. Cookies, browser session semantics, file uploads, and encoded/binary bodies remain out of scope for this first slice.
