### PR TITLE
Improve report endpoint triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add mailmap attribution for Jaykumar Gori's earlier commit identities.
 - Add initial Postman Collection v2.1 import support.
 - Add initial HAR 1.2 import support.
+- Improve Markdown and HTML reports with endpoint triage tables.
 
 ## 0.1.0 - 2026-04-25
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -28,6 +28,8 @@ Loadwright currently reports:
 - per-endpoint count, failures, average, and p95
 - threshold pass/fail results
 
+The HTML and Markdown reports include endpoint tables sorted for triage: failing endpoints first, then highest p95 latency, then highest average latency.
+
 ## Thresholds
 
 Thresholds live in the YAML spec:

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -209,6 +209,11 @@ func WriteAll(summary *Summary, outDir string) error {
 func RenderMarkdown(s *Summary) string {
 	var b strings.Builder
 	b.WriteString("# JMeter Test Summary\n\n")
+	status := "PASS"
+	if !s.Passed() {
+		status = "FAIL"
+	}
+	fmt.Fprintf(&b, "- Status: %s\n", status)
 	fmt.Fprintf(&b, "- Total samples: %d\n", s.TotalSamples)
 	fmt.Fprintf(&b, "- Successful: %d\n", s.Successful)
 	fmt.Fprintf(&b, "- Failed: %d\n", s.Failed)
@@ -226,6 +231,15 @@ func RenderMarkdown(s *Summary) string {
 			fmt.Fprintf(&b, "- %s: %s actual %.2f limit %.2f\n", threshold.Name, status, threshold.Actual, threshold.Limit)
 		}
 	}
+	if len(s.Endpoints) > 0 {
+		b.WriteString("\n## Endpoints\n\n")
+		b.WriteString("| Endpoint | Samples | Failed | Error rate | Average | p95 |\n")
+		b.WriteString("| --- | ---: | ---: | ---: | ---: | ---: |\n")
+		for _, row := range endpointRows(s) {
+			fmt.Fprintf(&b, "| %s | %d | %d | %.2f%% | %.2f ms | %.2f ms |\n",
+				escapeMarkdownCell(row.Name), row.Endpoint.Count, row.Endpoint.Failed, endpointErrorRate(row.Endpoint), row.Endpoint.AverageMS, row.Endpoint.P95MS)
+		}
+	}
 	return b.String()
 }
 
@@ -241,30 +255,56 @@ func RenderHTML(s *Summary) string {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Loadwright report</title>
   <style>
-    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #17202a; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-    .metric { border: 1px solid #d8dee4; border-radius: 8px; padding: 16px; }
-    .metric strong { display: block; font-size: 28px; margin-bottom: 4px; }
-    .pass { color: #166534; }
-    .fail { color: #991b1b; }
-    table { width: 100%%; border-collapse: collapse; margin-top: 24px; }
-    th, td { border-bottom: 1px solid #d8dee4; padding: 8px; text-align: left; }
+    :root { color-scheme: light; --ink: #17202a; --muted: #5f6b7a; --line: #d8dee4; --panel: #f6f8fa; --pass: #166534; --fail: #991b1b; }
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: var(--ink); background: #ffffff; }
+    main { max-width: 1120px; margin: 0 auto; padding: 32px 24px 48px; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+    h1 { font-size: 28px; line-height: 1.2; margin: 0; }
+    h2 { font-size: 18px; margin: 28px 0 12px; }
+    .badge { border-radius: 999px; font-size: 13px; font-weight: 700; padding: 4px 10px; border: 1px solid currentColor; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(156px, 1fr)); gap: 12px; }
+    .metric { border: 1px solid var(--line); border-radius: 8px; padding: 14px; background: var(--panel); }
+    .metric strong { display: block; font-size: 26px; line-height: 1.1; margin-bottom: 4px; }
+    .metric span { color: var(--muted); font-size: 13px; }
+    .pass { color: var(--pass); }
+    .fail { color: var(--fail); }
+    .empty { color: var(--muted); border: 1px solid var(--line); border-radius: 8px; padding: 14px; }
+    table { width: 100%%; border-collapse: collapse; margin-top: 8px; font-size: 14px; }
+    th, td { border-bottom: 1px solid var(--line); padding: 10px 8px; text-align: left; vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; background: #ffffff; }
+    td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .endpoint { max-width: 460px; overflow-wrap: anywhere; }
+    @media (max-width: 640px) {
+      main { padding: 24px 14px 40px; }
+      header { display: block; }
+      header .badge { display: inline-block; margin-top: 12px; }
+      table { display: block; overflow-x: auto; white-space: nowrap; }
+      .endpoint { min-width: 220px; }
+    }
   </style>
 </head>
 <body>
-  <h1>Loadwright report <span class="%s">%s</span></h1>
-  <div class="grid">
-    <div class="metric"><strong>%d</strong>Total samples</div>
-    <div class="metric"><strong>%d</strong>Failed</div>
-    <div class="metric"><strong>%.2f%%</strong>Error rate</div>
-    <div class="metric"><strong>%.2f ms</strong>Average</div>
-    <div class="metric"><strong>%.2f ms</strong>p95</div>
-    <div class="metric"><strong>%.2f ms</strong>p99</div>
-  </div>
-  %s
+  <main>
+    <header>
+      <h1>Loadwright report</h1>
+      <span class="badge %s">%s</span>
+    </header>
+    <section aria-label="Overview">
+      <div class="grid">
+        <div class="metric"><strong>%d</strong><span>Total samples</span></div>
+        <div class="metric"><strong>%d</strong><span>Failed</span></div>
+        <div class="metric"><strong>%.2f%%</strong><span>Error rate</span></div>
+        <div class="metric"><strong>%.2f ms</strong><span>Average</span></div>
+        <div class="metric"><strong>%.2f ms</strong><span>p95</span></div>
+        <div class="metric"><strong>%.2f ms</strong><span>p99</span></div>
+      </div>
+    </section>
+    %s
+    %s
+  </main>
 </body>
 </html>
-`, strings.ToLower(status), status, s.TotalSamples, s.Failed, s.ErrorRate, s.AverageMS, s.P95MS, s.P99MS, renderThresholdTable(s))
+`, strings.ToLower(status), status, s.TotalSamples, s.Failed, s.ErrorRate, s.AverageMS, s.P95MS, s.P99MS, renderThresholdTable(s), renderEndpointTable(s))
 }
 
 func RenderJUnit(s *Summary) string {
@@ -329,10 +369,10 @@ func junitThresholdCase(threshold ThresholdResult) junitTestCase {
 
 func renderThresholdTable(s *Summary) string {
 	if len(s.Thresholds) == 0 {
-		return ""
+		return `<section aria-labelledby="thresholds"><h2 id="thresholds">Thresholds</h2><p class="empty">No thresholds configured.</p></section>`
 	}
 	var b strings.Builder
-	b.WriteString("<h2>Thresholds</h2><table><thead><tr><th>Name</th><th>Actual</th><th>Limit</th><th>Status</th></tr></thead><tbody>")
+	b.WriteString(`<section aria-labelledby="thresholds"><h2 id="thresholds">Thresholds</h2><table><thead><tr><th>Name</th><th class="num">Actual</th><th class="num">Limit</th><th>Status</th></tr></thead><tbody>`)
 	for _, threshold := range s.Thresholds {
 		status := "PASS"
 		className := "pass"
@@ -340,10 +380,62 @@ func renderThresholdTable(s *Summary) string {
 			status = "FAIL"
 			className = "fail"
 		}
-		fmt.Fprintf(&b, "<tr><td>%s</td><td>%.2f</td><td>%.2f</td><td class=\"%s\">%s</td></tr>", html.EscapeString(threshold.Name), threshold.Actual, threshold.Limit, className, status)
+		fmt.Fprintf(&b, `<tr><td>%s</td><td class="num">%.2f</td><td class="num">%.2f</td><td class="%s">%s</td></tr>`, html.EscapeString(threshold.Name), threshold.Actual, threshold.Limit, className, status)
 	}
-	b.WriteString("</tbody></table>")
+	b.WriteString("</tbody></table></section>")
 	return b.String()
+}
+
+func renderEndpointTable(s *Summary) string {
+	if len(s.Endpoints) == 0 {
+		return `<section aria-labelledby="endpoints"><h2 id="endpoints">Endpoints</h2><p class="empty">No endpoint samples found.</p></section>`
+	}
+	var b strings.Builder
+	b.WriteString(`<section aria-labelledby="endpoints"><h2 id="endpoints">Endpoints</h2><table><thead><tr><th>Endpoint</th><th class="num">Samples</th><th class="num">Failed</th><th class="num">Error rate</th><th class="num">Average</th><th class="num">p95</th></tr></thead><tbody>`)
+	for _, row := range endpointRows(s) {
+		fmt.Fprintf(&b, `<tr><td class="endpoint">%s</td><td class="num">%d</td><td class="num">%d</td><td class="num">%.2f%%</td><td class="num">%.2f ms</td><td class="num">%.2f ms</td></tr>`,
+			html.EscapeString(row.Name), row.Endpoint.Count, row.Endpoint.Failed, endpointErrorRate(row.Endpoint), row.Endpoint.AverageMS, row.Endpoint.P95MS)
+	}
+	b.WriteString("</tbody></table></section>")
+	return b.String()
+}
+
+type endpointRow struct {
+	Name     string
+	Endpoint Endpoint
+}
+
+func endpointRows(s *Summary) []endpointRow {
+	rows := make([]endpointRow, 0, len(s.Endpoints))
+	for name, endpoint := range s.Endpoints {
+		rows = append(rows, endpointRow{Name: name, Endpoint: endpoint})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		left := rows[i].Endpoint
+		right := rows[j].Endpoint
+		if left.Failed != right.Failed {
+			return left.Failed > right.Failed
+		}
+		if left.P95MS != right.P95MS {
+			return left.P95MS > right.P95MS
+		}
+		if left.AverageMS != right.AverageMS {
+			return left.AverageMS > right.AverageMS
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	return rows
+}
+
+func endpointErrorRate(endpoint Endpoint) float64 {
+	if endpoint.Count == 0 {
+		return 0
+	}
+	return float64(endpoint.Failed) / float64(endpoint.Count) * 100
+}
+
+func escapeMarkdownCell(value string) string {
+	return strings.ReplaceAll(value, "|", `\|`)
 }
 
 func percentile(sorted []float64, pct float64) float64 {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -86,6 +86,9 @@ func TestRenderOutputsContainThresholdStatus(t *testing.T) {
 		Successful:   2,
 		AverageMS:    100,
 		P95MS:        150,
+		Endpoints: map[string]Endpoint{
+			"GET /health": {Count: 2, AverageMS: 100, P95MS: 150},
+		},
 		Thresholds: []ThresholdResult{{
 			Name:   "p95_ms_lt",
 			Limit:  200,
@@ -96,13 +99,60 @@ func TestRenderOutputsContainThresholdStatus(t *testing.T) {
 	if got := RenderMarkdown(summary); !strings.Contains(got, "p95_ms_lt: PASS") {
 		t.Fatalf("markdown missing threshold pass: %s", got)
 	}
-	if got := RenderHTML(summary); !strings.Contains(got, "p95_ms_lt") || !strings.Contains(got, "PASS") {
+	if got := RenderMarkdown(summary); !strings.Contains(got, "## Endpoints") ||
+		!strings.Contains(got, "| GET /health | 2 | 0 | 0.00% | 100.00 ms | 150.00 ms |") {
+		t.Fatalf("markdown missing endpoint table: %s", got)
+	}
+	if got := RenderHTML(summary); !strings.Contains(got, "p95_ms_lt") ||
+		!strings.Contains(got, "PASS") ||
+		!strings.Contains(got, "GET /health") ||
+		!strings.Contains(got, "Endpoints") {
 		t.Fatalf("html missing threshold table: %s", got)
 	}
 	if got := RenderJUnit(summary); !strings.Contains(got, `tests="2"`) ||
 		!strings.Contains(got, `name="p95_ms_lt"`) ||
 		strings.Contains(got, "<failure") {
 		t.Fatalf("junit missing passing threshold case: %s", got)
+	}
+}
+
+func TestRenderEndpointOrderingAndEscaping(t *testing.T) {
+	summary := &Summary{
+		TotalSamples: 6,
+		Successful:   4,
+		Failed:       2,
+		Endpoints: map[string]Endpoint{
+			"GET /fast":                  {Count: 2, Failed: 0, AverageMS: 50, P95MS: 60},
+			"GET /slow":                  {Count: 2, Failed: 0, AverageMS: 300, P95MS: 900},
+			"POST /danger?<script>|pipe": {Count: 2, Failed: 2, AverageMS: 200, P95MS: 250},
+		},
+	}
+	htmlReport := RenderHTML(summary)
+	failingIndex := strings.Index(htmlReport, "POST /danger?&lt;script&gt;|pipe")
+	slowIndex := strings.Index(htmlReport, "GET /slow")
+	fastIndex := strings.Index(htmlReport, "GET /fast")
+	if failingIndex < 0 || slowIndex < 0 || fastIndex < 0 {
+		t.Fatalf("html missing endpoints: %s", htmlReport)
+	}
+	if !(failingIndex < slowIndex && slowIndex < fastIndex) {
+		t.Fatalf("endpoints not sorted by triage priority: %s", htmlReport)
+	}
+	if strings.Contains(htmlReport, "<script>") {
+		t.Fatalf("html did not escape endpoint name: %s", htmlReport)
+	}
+	markdown := RenderMarkdown(summary)
+	if !strings.Contains(markdown, "POST /danger?<script>\\|pipe") {
+		t.Fatalf("markdown did not escape pipe in endpoint name: %s", markdown)
+	}
+}
+
+func TestRenderEmptyReportSections(t *testing.T) {
+	summary := &Summary{Endpoints: map[string]Endpoint{}}
+	htmlReport := RenderHTML(summary)
+	for _, want := range []string{"No thresholds configured.", "No endpoint samples found."} {
+		if !strings.Contains(htmlReport, want) {
+			t.Fatalf("html missing %q: %s", want, htmlReport)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #7.

Improves human-readable reports so users can quickly identify failing or slow endpoints without opening raw JSON.

## What Changed

- Adds endpoint tables to Markdown reports.
- Adds endpoint tables to HTML reports.
- Sorts endpoints by triage priority: failed samples first, then highest p95, then highest average latency.
- Renders explicit empty states for missing thresholds/endpoints in HTML.
- Tightens HTML report layout while keeping it static and dependency-free.
- Adds tests for endpoint ordering, HTML escaping, Markdown endpoint output, and empty report sections.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
- CLI smoke with `loadwright report` and endpoint assertions in generated `index.html` and `summary.md`

## Notes

This is intentionally static report polish. Historical trends, run comparisons, charts, and AI-generated explanations remain separate future slices.
