### PR TITLE
Add GitHub Actions CI example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,19 @@ jobs:
             bin/loadwright import openapi "$spec" -o "/tmp/loadwright-openapi/$name.loadwright.yaml"
             bin/loadwright compile "/tmp/loadwright-openapi/$name.loadwright.yaml" -o "/tmp/loadwright-openapi/$name.jmx"
           done
+      - name: Import Postman examples
+        run: |
+          mkdir -p /tmp/loadwright-postman
+          find examples/postman -name '*.json' -print | sort | while read -r collection; do
+            name="$(basename "$collection" .postman_collection.json)"
+            bin/loadwright import postman "$collection" -o "/tmp/loadwright-postman/$name.loadwright.yaml"
+            bin/loadwright compile "/tmp/loadwright-postman/$name.loadwright.yaml" -o "/tmp/loadwright-postman/$name.jmx"
+          done
+      - name: Import HAR examples
+        run: |
+          mkdir -p /tmp/loadwright-har
+          find examples/har -name '*.har' -print | sort | while read -r capture; do
+            name="$(basename "$capture" .har)"
+            bin/loadwright import har "$capture" -o "/tmp/loadwright-har/$name.loadwright.yaml"
+            bin/loadwright compile "/tmp/loadwright-har/$name.loadwright.yaml" -o "/tmp/loadwright-har/$name.jmx"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add initial Postman Collection v2.1 import support.
 - Add initial HAR 1.2 import support.
 - Improve Markdown and HTML reports with endpoint triage tables.
+- Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
 
 ## 0.1.0 - 2026-04-25
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -58,3 +58,40 @@ find examples -name '*.yaml' -not -path 'examples/openapi/*' -print | sort | whi
   fi
 done
 ```
+
+## Copy-Paste GitHub Actions Workflow
+
+See [examples/github-actions/loadwright-pr.yml](../examples/github-actions/loadwright-pr.yml) for a complete workflow users can copy into their own repository.
+
+The workflow has two jobs:
+
+- `validate`: runs on pull requests and pushes. It validates YAML specs and compiles them to JMX without starting JMeter.
+- `smoke`: runs only on pushes to `main`. It runs one threshold-gated smoke test and uploads the generated report artifacts.
+
+This split keeps pull request checks fast while still giving the default branch a real performance gate.
+
+Expected repository layout for the example:
+
+```text
+load-tests/
+  smoke.yaml
+.env.ci
+```
+
+If your specs do not need environment values, remove `--env-file .env.ci` from the workflow.
+
+For private APIs, keep secrets in GitHub Actions secrets and write `.env.ci` during the workflow:
+
+```yaml
+- name: Write Loadwright env
+  run: |
+    {
+      echo "API_BASE_URL=${API_BASE_URL}"
+      echo "API_TOKEN=${API_TOKEN}"
+    } > .env.ci
+  env:
+    API_BASE_URL: ${{ secrets.API_BASE_URL }}
+    API_TOKEN: ${{ secrets.API_TOKEN }}
+```
+
+Keep pull request runs small. Large load tests should run on `push`, `schedule`, or manual `workflow_dispatch` triggers where they will not slow every review cycle.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -109,6 +109,14 @@ bin/loadwright compile /tmp/checkout-har-loadwright.yaml -o /tmp/checkout-har.jm
 
 Demonstrates generating a starter Loadwright spec from a HAR 1.2 traffic capture.
 
+## GitHub Actions
+
+```bash
+cp examples/github-actions/loadwright-pr.yml .github/workflows/loadwright.yml
+```
+
+Demonstrates a downstream CI workflow with fast pull request validation and a threshold-gated smoke run on `main`.
+
 ## CSV Users
 
 ```bash

--- a/examples/github-actions/loadwright-pr.yml
+++ b/examples/github-actions/loadwright-pr.yml
@@ -1,0 +1,49 @@
+name: Loadwright
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  validate:
+    name: Validate load tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+      - name: Install Loadwright
+        run: go install github.com/devaryakjha/loadwright/cmd/loadwright@latest
+      - name: Validate and compile specs
+        run: |
+          mkdir -p /tmp/loadwright-compiled
+          find load-tests -name '*.yaml' -print | sort | while read -r spec; do
+            loadwright validate "$spec" --env-file .env.ci
+            loadwright compile "$spec" --env-file .env.ci -o "/tmp/loadwright-compiled/$(basename "$spec" .yaml).jmx"
+          done
+
+  smoke:
+    name: Threshold smoke
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+      - name: Install Loadwright
+        run: go install github.com/devaryakjha/loadwright/cmd/loadwright@latest
+      - name: Run smoke load test
+        run: loadwright run load-tests/smoke.yaml --env-file .env.ci --out-dir results/smoke --ci
+      - name: Upload Loadwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: loadwright-smoke-report
+          path: results/smoke/


### PR DESCRIPTION
## Summary

Closes #9.

Adds a copy-paste GitHub Actions workflow for downstream Loadwright users and expands this repository's CI to exercise the current import examples.

## What Changed

- Adds `examples/github-actions/loadwright-pr.yml` with fast PR validation and a threshold-gated smoke job on `main`.
- Documents CI layout, secrets/env-file handling, artifact upload, and when to run larger load tests.
- Links the workflow from examples docs.
- Extends repository CI to import and compile Postman and HAR examples in addition to OpenAPI examples.
- Uses current Node 24-compatible action majors, including `actions/upload-artifact@v7`.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `actionlint .github/workflows/ci.yml examples/github-actions/loadwright-pr.yml`
- YAML parse check for both workflow files
- Build plus OpenAPI/Postman/HAR import-and-compile smoke
