### PR TITLE
Add latest run pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add initial HAR 1.2 import support.
 - Improve Markdown and HTML reports with endpoint triage tables.
 - Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
+- Add latest-run metadata for default `loadwright run` result directories.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Reports are written to `results/<run-id>/`:
 - `index.html`
 - `junit.xml`
 
+Default runs also update `results/latest.json` so the newest report can be found without copying the timestamped run ID.
+
 ## Example Spec
 
 ```yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,8 @@ The run writes artifacts to `results/<run-id>/`:
 - `index.html`
 - `junit.xml`
 
+Default runs also update `results/latest.json`, and create a best-effort `results/latest` symlink on platforms that support it.
+
 ## Compile Without Running
 
 ```bash

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,6 +16,19 @@ bin/loadwright report results/manual-smoke/results.jtl --out-dir results/manual-
 - `index.html`: standalone human-readable report
 - `junit.xml`: CI-friendly JUnit report for sample and threshold failures
 
+When `loadwright run` uses the default output directory, Loadwright also writes `results/latest.json`:
+
+```json
+{
+  "run_id": "20260425-120000",
+  "run_dir": "results/20260425-120000",
+  "report": "results/20260425-120000/index.html",
+  "updated_at": "2026-04-25T12:00:00Z"
+}
+```
+
+On platforms that support symlinks, `results/latest` points at the newest default run directory. Explicit `--out-dir` runs do not update `results/latest.json`.
+
 ## Metrics
 
 Loadwright currently reports:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -186,6 +187,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
+	updateLatest := outputDir == ""
 	runID := time.Now().UTC().Format("20060102-150405")
 	if outputDir == "" {
 		outputDir = filepath.Join("results", runID)
@@ -236,12 +238,69 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "write report failed: %v\n", err)
 		return 1
 	}
+	if updateLatest {
+		if err := writeLatestRun("results", outputDir, time.Now().UTC()); err != nil {
+			fmt.Fprintf(stderr, "warning: update latest run pointer: %v\n", err)
+		}
+	}
 	fmt.Fprintf(stdout, "report %s\n", filepath.Join(outputDir, "index.html"))
 	if ci && !summary.Passed() {
 		fmt.Fprintln(stderr, "thresholds failed")
 		return 1
 	}
 	return 0
+}
+
+type latestRun struct {
+	RunID     string `json:"run_id"`
+	RunDir    string `json:"run_dir"`
+	Report    string `json:"report"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func writeLatestRun(resultsRoot string, outputDir string, updatedAt time.Time) error {
+	if err := os.MkdirAll(resultsRoot, 0o755); err != nil {
+		return err
+	}
+	runDir := filepath.Clean(outputDir)
+	relativeRunDir, err := filepath.Rel(resultsRoot, runDir)
+	if err == nil && !strings.HasPrefix(relativeRunDir, "..") && relativeRunDir != "." {
+		runDir = filepath.ToSlash(filepath.Join(resultsRoot, relativeRunDir))
+	}
+	metadata := latestRun{
+		RunID:     filepath.Base(outputDir),
+		RunDir:    filepath.ToSlash(runDir),
+		Report:    filepath.ToSlash(filepath.Join(runDir, "index.html")),
+		UpdatedAt: updatedAt.Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	latestPath := filepath.Join(resultsRoot, "latest.json")
+	if err := os.WriteFile(latestPath, data, 0o644); err != nil {
+		return err
+	}
+	writeLatestSymlink(resultsRoot, outputDir)
+	return nil
+}
+
+func writeLatestSymlink(resultsRoot string, outputDir string) {
+	latestPath := filepath.Join(resultsRoot, "latest")
+	if info, err := os.Lstat(latestPath); err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return
+		}
+		if err := os.Remove(latestPath); err != nil {
+			return
+		}
+	}
+	target, err := filepath.Rel(resultsRoot, outputDir)
+	if err != nil || strings.HasPrefix(target, "..") || target == "." {
+		return
+	}
+	_ = os.Symlink(target, latestPath)
 }
 
 func reportCommand(args []string, stdout io.Writer, stderr io.Writer) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -547,6 +548,99 @@ thresholds:
 	}
 }
 
+func TestRunSpecDefaultOutputCreatesLatestPointer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: latest-run
+target: https://example.com
+requests:
+  - name: health
+    path: /health
+`
+	if err := os.WriteFile("spec.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "spec.yaml"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	metadata := readLatestRun(t, filepath.Join("results", "latest.json"))
+	if metadata.RunID == "" {
+		t.Fatalf("expected run_id in latest metadata: %+v", metadata)
+	}
+	if metadata.RunDir != filepath.ToSlash(filepath.Join("results", metadata.RunID)) {
+		t.Fatalf("unexpected run_dir: %+v", metadata)
+	}
+	if metadata.Report != filepath.ToSlash(filepath.Join("results", metadata.RunID, "index.html")) {
+		t.Fatalf("unexpected report path: %+v", metadata)
+	}
+	if _, err := os.Stat(filepath.FromSlash(metadata.Report)); err != nil {
+		t.Fatalf("expected latest report path to exist: %v", err)
+	}
+}
+
+func TestRunSpecExplicitOutputDoesNotCreateLatestPointer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: explicit-run
+target: https://example.com
+requests:
+  - path: /health
+`
+	if err := os.WriteFile("spec.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "spec.yaml", "--out-dir", "results/manual"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join("results", "latest.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no latest pointer for explicit out-dir, err=%v", err)
+	}
+}
+
+func TestRunSpecThresholdFailureStillCreatesLatestPointer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: failing-latest-run
+target: https://example.com
+requests:
+  - name: health
+    path: /health
+thresholds:
+  p95_ms_lt: 1
+`
+	if err := os.WriteFile("spec.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "spec.yaml", "--ci"}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "thresholds failed") {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	metadata := readLatestRun(t, filepath.Join("results", "latest.json"))
+	if metadata.Report == "" {
+		t.Fatalf("expected latest metadata despite threshold failure: %+v", metadata)
+	}
+	if _, err := os.Stat(filepath.FromSlash(metadata.Report)); err != nil {
+		t.Fatalf("expected latest report path to exist: %v", err)
+	}
+}
+
 func chdir(t *testing.T, dir string) {
 	t.Helper()
 	previous, err := os.Getwd()
@@ -561,6 +655,19 @@ func chdir(t *testing.T, dir string) {
 			t.Fatalf("restore working directory: %v", err)
 		}
 	})
+}
+
+func readLatestRun(t *testing.T, path string) latestRun {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata latestRun
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	return metadata
 }
 
 func installDockerShim(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary

Closes #11.

Adds latest-run metadata for default `loadwright run` output so users and CI jobs can find the newest report without copying the timestamped run directory.

## What Changed

- Default runs still write to `results/<run-id>/`.
- Default runs now write `results/latest.json` with `run_id`, `run_dir`, `report`, and `updated_at`.
- Default runs create a best-effort `results/latest` symlink when the platform/filesystem allows it.
- Explicit `--out-dir` runs do not update the default latest pointer.
- Threshold-failed `--ci` runs still update the latest pointer after reports are written.
- Adds docs and CLI tests for default, explicit, and threshold-failure behavior.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`

## Notes

The symlink is intentionally best-effort. `results/latest.json` is the portable contract for platforms where symlink creation is unavailable or restricted.
