### PR TITLE
Add report comparison command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Improve Markdown and HTML reports with endpoint triage tables.
 - Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
 - Add latest-run metadata for default `loadwright run` result directories.
+- Add `loadwright compare` for Markdown comparisons between two `summary.json` files.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ loadwright validate <spec.yaml> [--env-file .env.test]
 loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
 loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]
 loadwright report <results.jtl> [--out-dir results/report] [--error-rate-lt 1] [--p95-ms-lt 3000] [--avg-ms-lt 1000] [--ci]
+loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparison.md]
 ```
 
 `doctor --deep` runs the configured JMeter Docker image and verifies that JMeter starts.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -69,6 +69,25 @@ bin/loadwright report results.jtl \
 
 The report command writes artifacts before checking the `--ci` exit status, so failed threshold runs still leave inspectable summaries behind.
 
+## Compare Runs
+
+Compare two Loadwright `summary.json` files:
+
+```bash
+bin/loadwright compare results/baseline/summary.json results/candidate/summary.json
+```
+
+Write the comparison to a Markdown file:
+
+```bash
+bin/loadwright compare \
+  results/baseline/summary.json \
+  results/candidate/summary.json \
+  -o results/comparison.md
+```
+
+The comparison includes top-level metric deltas plus per-endpoint deltas for failure count, error rate, average latency, and p95 latency. Added and removed endpoints are called out in the endpoint table.
+
 ## JUnit
 
 `junit.xml` contains one testcase for sample failures and one testcase per threshold. This makes Loadwright reports consumable by CI systems that understand JUnit test reports.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -44,6 +44,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return run(args[1:], stdout, stderr)
 	case "report":
 		return reportCommand(args[1:], stdout, stderr)
+	case "compare":
+		return compareCommand(args[1:], stdout, stderr)
 	case "import":
 		return importCommand(args[1:], stdout, stderr)
 	default:
@@ -67,6 +69,7 @@ Usage:
   loadwright compile <spec.yaml> [-o tests/name.jmx] [--env-file .env.test]
   loadwright run <spec.yaml|test.jmx> [--out-dir results/run] [--env-file .env.test] [--ci]
   loadwright report <results.jtl> [--out-dir results/report] [--error-rate-lt 1] [--p95-ms-lt 3000] [--avg-ms-lt 1000] [--ci]
+  loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparison.md]
 
 Commands:
   doctor    Check local Docker/JMeter prerequisites
@@ -76,7 +79,8 @@ Commands:
   validate  Validate a YAML spec without compiling or running JMeter
   compile   Compile a YAML spec to JMeter JMX
   run       Run a YAML spec or existing JMX through Dockerized JMeter
-  report    Generate reports from an existing JMeter JTL file`)
+  report    Generate reports from an existing JMeter JTL file
+  compare   Compare two Loadwright summary.json files`)
 }
 
 func doctor(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -329,6 +333,39 @@ func reportCommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "thresholds failed")
 		return 1
 	}
+	return 0
+}
+
+func compareCommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	baselinePath, candidatePath, output, err := parseCompareArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	baseline, err := report.LoadSummaryFile(baselinePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load baseline summary failed: %v\n", err)
+		return 1
+	}
+	candidate, err := report.LoadSummaryFile(candidatePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load candidate summary failed: %v\n", err)
+		return 1
+	}
+	markdown := report.RenderComparisonMarkdown(report.CompareSummaries(baseline, candidate))
+	if output == "" {
+		fmt.Fprint(stdout, markdown)
+		return 0
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		fmt.Fprintf(stderr, "create comparison output dir: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(output, []byte(markdown), 0o644); err != nil {
+		fmt.Fprintf(stderr, "write comparison failed: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "wrote %s\n", output)
 	return 0
 }
 
@@ -632,6 +669,31 @@ func parseReportArgs(args []string) (jtlPath string, outputDir string, threshold
 		return "", "", thresholds, false, fmt.Errorf("report requires exactly one JTL path")
 	}
 	return positional[0], outputDir, thresholds, ci, nil
+}
+
+func parseCompareArgs(args []string) (baselinePath string, candidatePath string, output string, err error) {
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-o" || arg == "--out":
+			i++
+			if i >= len(args) {
+				return "", "", "", fmt.Errorf("%s requires a value", arg)
+			}
+			output = args[i]
+		case strings.HasPrefix(arg, "-o="):
+			output = strings.TrimPrefix(arg, "-o=")
+		case strings.HasPrefix(arg, "--out="):
+			output = strings.TrimPrefix(arg, "--out=")
+		default:
+			positional = append(positional, arg)
+		}
+	}
+	if len(positional) != 2 {
+		return "", "", "", fmt.Errorf("compare requires exactly two summary paths")
+	}
+	return positional[0], positional[1], output, nil
 }
 
 func parseThresholdValue(flag string, raw string) (float64, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -119,6 +119,25 @@ func TestParseReportArgsErrors(t *testing.T) {
 	}
 }
 
+func TestParseCompareArgs(t *testing.T) {
+	baseline, candidate, output, err := parseCompareArgs([]string{"baseline.json", "candidate.json", "--out=comparison.md"})
+	if err != nil {
+		t.Fatalf("parseCompareArgs() error = %v", err)
+	}
+	if baseline != "baseline.json" || candidate != "candidate.json" || output != "comparison.md" {
+		t.Fatalf("unexpected args: baseline=%q candidate=%q output=%q", baseline, candidate, output)
+	}
+}
+
+func TestParseCompareArgsErrors(t *testing.T) {
+	if _, _, _, err := parseCompareArgs([]string{"baseline.json"}); err == nil {
+		t.Fatalf("expected missing candidate error")
+	}
+	if _, _, _, err := parseCompareArgs([]string{"baseline.json", "candidate.json", "--out"}); err == nil {
+		t.Fatalf("expected missing output value error")
+	}
+}
+
 func TestParseDoctorArgs(t *testing.T) {
 	deep, image, err := parseDoctorArgs([]string{"--deep", "--image=custom:jmeter"})
 	if err != nil {
@@ -483,6 +502,77 @@ func TestRunReportFailsCIOnThresholds(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join("report-out", "summary.json")); err != nil {
 		t.Fatalf("expected report artifacts despite failed thresholds: %v", err)
+	}
+}
+
+func TestRunCompareWritesMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	baseline := `{
+  "total_samples": 2,
+  "successful": 2,
+  "failed": 0,
+  "error_rate": 0,
+  "average_ms": 100,
+  "p95_ms": 150,
+  "p99_ms": 180,
+  "endpoints": {
+    "GET /health": {"count": 2, "failed": 0, "average_ms": 100, "p95_ms": 150}
+  }
+}`
+	candidate := `{
+  "total_samples": 2,
+  "successful": 1,
+  "failed": 1,
+  "error_rate": 50,
+  "average_ms": 250,
+  "p95_ms": 400,
+  "p99_ms": 450,
+  "endpoints": {
+    "GET /health": {"count": 2, "failed": 1, "average_ms": 250, "p95_ms": 400}
+  }
+}`
+	if err := os.WriteFile("baseline.json", []byte(baseline), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("candidate.json", []byte(candidate), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"compare", "baseline.json", "candidate.json", "--out", "comparison.md"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(compare) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile("comparison.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "# Loadwright Comparison") ||
+		!strings.Contains(string(data), "| Failed samples | 0 | 1 | +1 |") ||
+		!strings.Contains(string(data), "| GET /health | changed | 0 | 1 | +50.00% | +150.00 ms | +250.00 ms |") {
+		t.Fatalf("unexpected comparison:\n%s", data)
+	}
+	if !strings.Contains(stdout.String(), "wrote comparison.md") {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+}
+
+func TestRunComparePrintsMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.WriteFile("baseline.json", []byte(`{"total_samples":1,"endpoints":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("candidate.json", []byte(`{"total_samples":2,"endpoints":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"compare", "baseline.json", "candidate.json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(compare) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "| Total samples | 1 | 2 | +1 |") {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
 	}
 }
 

--- a/internal/report/compare.go
+++ b/internal/report/compare.go
@@ -1,0 +1,146 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+type Comparison struct {
+	Baseline  *Summary
+	Candidate *Summary
+	Endpoints []EndpointComparison
+}
+
+type EndpointComparison struct {
+	Name      string
+	Status    string
+	Baseline  Endpoint
+	Candidate Endpoint
+}
+
+func LoadSummaryFile(path string) (*Summary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read summary: %w", err)
+	}
+	var summary Summary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil, fmt.Errorf("parse summary JSON: %w", err)
+	}
+	if summary.Endpoints == nil {
+		summary.Endpoints = map[string]Endpoint{}
+	}
+	return &summary, nil
+}
+
+func CompareSummaries(baseline *Summary, candidate *Summary) *Comparison {
+	if baseline.Endpoints == nil {
+		baseline.Endpoints = map[string]Endpoint{}
+	}
+	if candidate.Endpoints == nil {
+		candidate.Endpoints = map[string]Endpoint{}
+	}
+	names := map[string]bool{}
+	for name := range baseline.Endpoints {
+		names[name] = true
+	}
+	for name := range candidate.Endpoints {
+		names[name] = true
+	}
+	endpoints := make([]EndpointComparison, 0, len(names))
+	for name := range names {
+		base, hasBase := baseline.Endpoints[name]
+		next, hasCandidate := candidate.Endpoints[name]
+		status := "changed"
+		switch {
+		case hasBase && !hasCandidate:
+			status = "removed"
+		case !hasBase && hasCandidate:
+			status = "added"
+		}
+		endpoints = append(endpoints, EndpointComparison{
+			Name:      name,
+			Status:    status,
+			Baseline:  base,
+			Candidate: next,
+		})
+	}
+	sort.Slice(endpoints, func(i, j int) bool {
+		left := endpoints[i]
+		right := endpoints[j]
+		leftRank := comparisonStatusRank(left.Status)
+		rightRank := comparisonStatusRank(right.Status)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftP95Delta := left.Candidate.P95MS - left.Baseline.P95MS
+		rightP95Delta := right.Candidate.P95MS - right.Baseline.P95MS
+		if leftP95Delta != rightP95Delta {
+			return leftP95Delta > rightP95Delta
+		}
+		return left.Name < right.Name
+	})
+	return &Comparison{Baseline: baseline, Candidate: candidate, Endpoints: endpoints}
+}
+
+func RenderComparisonMarkdown(c *Comparison) string {
+	var b strings.Builder
+	b.WriteString("# Loadwright Comparison\n\n")
+	b.WriteString("## Overview\n\n")
+	b.WriteString("| Metric | Baseline | Candidate | Delta |\n")
+	b.WriteString("| --- | ---: | ---: | ---: |\n")
+	writeIntMetric(&b, "Total samples", c.Baseline.TotalSamples, c.Candidate.TotalSamples)
+	writeIntMetric(&b, "Failed samples", c.Baseline.Failed, c.Candidate.Failed)
+	writeFloatMetric(&b, "Error rate", c.Baseline.ErrorRate, c.Candidate.ErrorRate, "%")
+	writeFloatMetric(&b, "Average", c.Baseline.AverageMS, c.Candidate.AverageMS, " ms")
+	writeFloatMetric(&b, "p95", c.Baseline.P95MS, c.Candidate.P95MS, " ms")
+	writeFloatMetric(&b, "p99", c.Baseline.P99MS, c.Candidate.P99MS, " ms")
+
+	b.WriteString("\n## Endpoints\n\n")
+	if len(c.Endpoints) == 0 {
+		b.WriteString("No endpoint data found.\n")
+		return b.String()
+	}
+	b.WriteString("| Endpoint | Status | Baseline failed | Candidate failed | Error rate delta | Average delta | p95 delta |\n")
+	b.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, endpoint := range c.Endpoints {
+		fmt.Fprintf(&b, "| %s | %s | %d | %d | %s | %s | %s |\n",
+			escapeMarkdownCell(endpoint.Name),
+			endpoint.Status,
+			endpoint.Baseline.Failed,
+			endpoint.Candidate.Failed,
+			formatSignedFloat(endpointErrorRate(endpoint.Candidate)-endpointErrorRate(endpoint.Baseline), "%"),
+			formatSignedFloat(endpoint.Candidate.AverageMS-endpoint.Baseline.AverageMS, " ms"),
+			formatSignedFloat(endpoint.Candidate.P95MS-endpoint.Baseline.P95MS, " ms"),
+		)
+	}
+	return b.String()
+}
+
+func writeIntMetric(b *strings.Builder, name string, baseline int, candidate int) {
+	fmt.Fprintf(b, "| %s | %d | %d | %+d |\n", name, baseline, candidate, candidate-baseline)
+}
+
+func writeFloatMetric(b *strings.Builder, name string, baseline float64, candidate float64, suffix string) {
+	fmt.Fprintf(b, "| %s | %.2f%s | %.2f%s | %s |\n", name, baseline, suffix, candidate, suffix, formatSignedFloat(candidate-baseline, suffix))
+}
+
+func formatSignedFloat(value float64, suffix string) string {
+	return fmt.Sprintf("%+.2f%s", value, suffix)
+}
+
+func comparisonStatusRank(status string) int {
+	switch status {
+	case "changed":
+		return 0
+	case "added":
+		return 1
+	case "removed":
+		return 2
+	default:
+		return 3
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,6 +199,68 @@ func TestWriteAllCreatesArtifacts(t *testing.T) {
 	}
 }
 
+func TestLoadSummaryFileAndRenderComparison(t *testing.T) {
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+	candidatePath := filepath.Join(dir, "candidate.json")
+	writeSummaryJSON(t, baselinePath, Summary{
+		TotalSamples: 10,
+		Successful:   9,
+		Failed:       1,
+		ErrorRate:    10,
+		AverageMS:    100,
+		P95MS:        200,
+		P99MS:        250,
+		Endpoints: map[string]Endpoint{
+			"GET /stable":  {Count: 5, Failed: 0, AverageMS: 80, P95MS: 100},
+			"GET /removed": {Count: 5, Failed: 1, AverageMS: 120, P95MS: 200},
+		},
+	})
+	writeSummaryJSON(t, candidatePath, Summary{
+		TotalSamples: 12,
+		Successful:   10,
+		Failed:       2,
+		ErrorRate:    16.67,
+		AverageMS:    150,
+		P95MS:        260,
+		P99MS:        300,
+		Endpoints: map[string]Endpoint{
+			"GET /stable":           {Count: 6, Failed: 1, AverageMS: 130, P95MS: 240},
+			"POST /added|expensive": {Count: 6, Failed: 1, AverageMS: 170, P95MS: 280},
+		},
+	})
+	baseline, err := LoadSummaryFile(baselinePath)
+	if err != nil {
+		t.Fatalf("LoadSummaryFile(baseline) error = %v", err)
+	}
+	candidate, err := LoadSummaryFile(candidatePath)
+	if err != nil {
+		t.Fatalf("LoadSummaryFile(candidate) error = %v", err)
+	}
+	markdown := RenderComparisonMarkdown(CompareSummaries(baseline, candidate))
+	for _, want := range []string{
+		"| Total samples | 10 | 12 | +2 |",
+		"| Error rate | 10.00% | 16.67% | +6.67% |",
+		"| GET /stable | changed | 0 | 1 | +16.67% | +50.00 ms | +140.00 ms |",
+		"POST /added\\|expensive",
+		"| GET /removed | removed | 1 | 0 | -20.00% | -120.00 ms | -200.00 ms |",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("comparison missing %q:\n%s", want, markdown)
+		}
+	}
+	if strings.Index(markdown, "GET /stable") > strings.Index(markdown, "POST /added\\|expensive") {
+		t.Fatalf("changed endpoints should sort before added endpoints:\n%s", markdown)
+	}
+}
+
+func TestRenderComparisonWithoutEndpoints(t *testing.T) {
+	markdown := RenderComparisonMarkdown(CompareSummaries(&Summary{}, &Summary{}))
+	if !strings.Contains(markdown, "No endpoint data found.") {
+		t.Fatalf("comparison missing empty endpoint message:\n%s", markdown)
+	}
+}
+
 func writeJTL(t *testing.T, contents string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -206,4 +269,15 @@ func writeJTL(t *testing.T, contents string) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func writeSummaryJSON(t *testing.T, path string, summary Summary) {
+	t.Helper()
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Summary

Closes #13.

Adds `loadwright compare` for deterministic Markdown comparisons between two Loadwright `summary.json` files.

## What Changed

- Adds `loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparison.md]`.
- Loads existing Loadwright `summary.json` files directly.
- Compares total samples, failed samples, error rate, average, p95, and p99.
- Compares shared endpoints and marks added/removed endpoints.
- Prints Markdown to stdout by default or writes to `--out`.
- Documents comparison usage in reports docs and README command list.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
- CLI smoke comparing two temporary summary files and writing `comparison.md`

## Notes

This is a file-to-file comparison only. Historical trend storage and run databases remain separate future work.
