### PR TITLE
Add run metadata manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
 - Add latest-run metadata for default `loadwright run` result directories.
 - Add `loadwright compare` for Markdown comparisons between two `summary.json` files.
+- Add per-run `run.json` metadata manifests.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Reports are written to `results/<run-id>/`:
 - `summary.md`
 - `index.html`
 - `junit.xml`
+- `run.json`
 
 Default runs also update `results/latest.json` so the newest report can be found without copying the timestamped run ID.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ The run writes artifacts to `results/<run-id>/`:
 - `summary.md`
 - `index.html`
 - `junit.xml`
+- `run.json`
 
 Default runs also update `results/latest.json`, and create a best-effort `results/latest` symlink on platforms that support it.
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -15,6 +15,30 @@ bin/loadwright report results/manual-smoke/results.jtl --out-dir results/manual-
 - `summary.md`: concise Markdown summary
 - `index.html`: standalone human-readable report
 - `junit.xml`: CI-friendly JUnit report for sample and threshold failures
+- `run.json`: metadata about the run input, JMeter image, timings, and artifact paths
+
+`run.json` does not record environment variable values or env-file contents.
+
+```json
+{
+  "run_id": "20260425-120000",
+  "input": "loadwright.yaml",
+  "input_type": "yaml",
+  "jmx": "results/20260425-120000/example-api.jmx",
+  "generated_jmx": true,
+  "image": "justb4/jmeter:latest",
+  "ci": true,
+  "started_at": "2026-04-25T12:00:00Z",
+  "finished_at": "2026-04-25T12:00:10Z",
+  "artifacts": {
+    "results_jtl": "results/20260425-120000/results.jtl",
+    "summary_json": "results/20260425-120000/summary.json",
+    "summary_md": "results/20260425-120000/summary.md",
+    "report_html": "results/20260425-120000/index.html",
+    "junit_xml": "results/20260425-120000/junit.xml"
+  }
+}
+```
 
 When `loadwright run` uses the default output directory, Loadwright also writes `results/latest.json`:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -191,8 +191,9 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
+	startedAt := time.Now().UTC()
 	updateLatest := outputDir == ""
-	runID := time.Now().UTC().Format("20060102-150405")
+	runID := startedAt.Format("20060102-150405")
 	if outputDir == "" {
 		outputDir = filepath.Join("results", runID)
 	}
@@ -203,6 +204,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	var thresholds spec.Thresholds
 	jmxPath := input
+	generatedJMX := false
 	workDir := "."
 	if isYAML(input) {
 		loaded, err := loadResolvedSpec(input, envFile)
@@ -216,6 +218,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "compile failed: %v\n", err)
 			return 1
 		}
+		generatedJMX = true
 		workDir = outputDir
 		fmt.Fprintf(stdout, "compiled %s\n", jmxPath)
 	}
@@ -242,8 +245,30 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "write report failed: %v\n", err)
 		return 1
 	}
+	finishedAt := time.Now().UTC()
+	if err := writeRunManifest(runManifest{
+		RunID:        filepath.Base(outputDir),
+		Input:        filepath.ToSlash(input),
+		InputType:    runInputType(input),
+		JMX:          filepath.ToSlash(jmxPath),
+		GeneratedJMX: generatedJMX,
+		Image:        image,
+		CI:           ci,
+		StartedAt:    startedAt.Format(time.RFC3339),
+		FinishedAt:   finishedAt.Format(time.RFC3339),
+		Artifacts: runArtifacts{
+			ResultsJTL:  filepath.ToSlash(filepath.Join(outputDir, jtlName)),
+			SummaryJSON: filepath.ToSlash(filepath.Join(outputDir, "summary.json")),
+			SummaryMD:   filepath.ToSlash(filepath.Join(outputDir, "summary.md")),
+			ReportHTML:  filepath.ToSlash(filepath.Join(outputDir, "index.html")),
+			JUnitXML:    filepath.ToSlash(filepath.Join(outputDir, "junit.xml")),
+		},
+	}, outputDir); err != nil {
+		fmt.Fprintf(stderr, "write run metadata failed: %v\n", err)
+		return 1
+	}
 	if updateLatest {
-		if err := writeLatestRun("results", outputDir, time.Now().UTC()); err != nil {
+		if err := writeLatestRun("results", outputDir, finishedAt); err != nil {
 			fmt.Fprintf(stderr, "warning: update latest run pointer: %v\n", err)
 		}
 	}
@@ -253,6 +278,43 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+type runManifest struct {
+	RunID        string       `json:"run_id"`
+	Input        string       `json:"input"`
+	InputType    string       `json:"input_type"`
+	JMX          string       `json:"jmx"`
+	GeneratedJMX bool         `json:"generated_jmx"`
+	Image        string       `json:"image"`
+	CI           bool         `json:"ci"`
+	StartedAt    string       `json:"started_at"`
+	FinishedAt   string       `json:"finished_at"`
+	Artifacts    runArtifacts `json:"artifacts"`
+}
+
+type runArtifacts struct {
+	ResultsJTL  string `json:"results_jtl"`
+	SummaryJSON string `json:"summary_json"`
+	SummaryMD   string `json:"summary_md"`
+	ReportHTML  string `json:"report_html"`
+	JUnitXML    string `json:"junit_xml"`
+}
+
+func writeRunManifest(manifest runManifest, outputDir string) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(filepath.Join(outputDir, "run.json"), data, 0o644)
+}
+
+func runInputType(path string) string {
+	if isYAML(path) {
+		return "yaml"
+	}
+	return "jmx"
 }
 
 type latestRun struct {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -623,7 +623,7 @@ thresholds:
 	if code != 0 {
 		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	for _, name := range []string{"shim-run.jmx", "results.jtl", "summary.json", "summary.md", "index.html", "junit.xml"} {
+	for _, name := range []string{"shim-run.jmx", "results.jtl", "summary.json", "summary.md", "index.html", "junit.xml", "run.json"} {
 		if _, err := os.Stat(filepath.Join("results", "smoke", name)); err != nil {
 			t.Fatalf("expected %s: %v", name, err)
 		}
@@ -635,6 +635,23 @@ thresholds:
 	if !strings.Contains(string(summary), `"total_samples": 1`) ||
 		!strings.Contains(string(summary), `"failed": 0`) {
 		t.Fatalf("unexpected summary: %s", summary)
+	}
+	manifest := readRunManifest(t, filepath.Join("results", "smoke", "run.json"))
+	if manifest.RunID != "smoke" || manifest.Input != "spec.yaml" || manifest.InputType != "yaml" || !manifest.GeneratedJMX {
+		t.Fatalf("unexpected run manifest: %+v", manifest)
+	}
+	if manifest.JMX != filepath.ToSlash(filepath.Join("results", "smoke", "shim-run.jmx")) {
+		t.Fatalf("unexpected JMX path: %+v", manifest)
+	}
+	if manifest.Image != "justb4/jmeter:latest" || !manifest.CI {
+		t.Fatalf("unexpected run flags: %+v", manifest)
+	}
+	if manifest.Artifacts.ReportHTML != filepath.ToSlash(filepath.Join("results", "smoke", "index.html")) ||
+		manifest.Artifacts.ResultsJTL != filepath.ToSlash(filepath.Join("results", "smoke", "results.jtl")) {
+		t.Fatalf("unexpected artifacts: %+v", manifest.Artifacts)
+	}
+	if manifest.StartedAt == "" || manifest.FinishedAt == "" {
+		t.Fatalf("expected timestamps: %+v", manifest)
 	}
 }
 
@@ -671,6 +688,10 @@ requests:
 	}
 	if _, err := os.Stat(filepath.FromSlash(metadata.Report)); err != nil {
 		t.Fatalf("expected latest report path to exist: %v", err)
+	}
+	manifest := readRunManifest(t, filepath.Join("results", metadata.RunID, "run.json"))
+	if manifest.RunID != metadata.RunID || manifest.Artifacts.ReportHTML != metadata.Report {
+		t.Fatalf("latest metadata and run manifest disagree: latest=%+v run=%+v", metadata, manifest)
 	}
 }
 
@@ -731,6 +752,67 @@ thresholds:
 	}
 }
 
+func TestRunExistingJMXCreatesRunManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	if err := os.WriteFile("existing.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "existing.jmx", "--out-dir", "results/jmx-smoke", "--image", "custom:jmeter"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run existing JMX) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	manifest := readRunManifest(t, filepath.Join("results", "jmx-smoke", "run.json"))
+	if manifest.Input != "existing.jmx" || manifest.InputType != "jmx" || manifest.GeneratedJMX {
+		t.Fatalf("unexpected JMX manifest: %+v", manifest)
+	}
+	if manifest.JMX != "existing.jmx" || manifest.Image != "custom:jmeter" || manifest.CI {
+		t.Fatalf("unexpected JMX manifest fields: %+v", manifest)
+	}
+}
+
+func TestRunManifestDoesNotIncludeEnvValues(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: secret-run
+target: https://example.com
+variables:
+  token: ${API_TOKEN}
+auth:
+  type: bearer
+  token: "{{token}}"
+requests:
+  - path: /secure
+`
+	if err := os.WriteFile("spec.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(".env.test", []byte("API_TOKEN=super-secret-token\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "spec.yaml", "--env-file", ".env.test", "--out-dir", "results/secret"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(filepath.Join("results", "secret", "run.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "super-secret-token") || strings.Contains(string(data), "API_TOKEN") || strings.Contains(string(data), ".env.test") {
+		t.Fatalf("run manifest leaked env data: %s", data)
+	}
+}
+
 func chdir(t *testing.T, dir string) {
 	t.Helper()
 	previous, err := os.Getwd()
@@ -758,6 +840,19 @@ func readLatestRun(t *testing.T, path string) latestRun {
 		t.Fatal(err)
 	}
 	return metadata
+}
+
+func readRunManifest(t *testing.T, path string) runManifest {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest runManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
 }
 
 func installDockerShim(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary

Closes #14.

Adds per-run `run.json` metadata manifests to Loadwright run output directories.

## What Changed

- Writes `run.json` after report artifacts are generated.
- Records run id, input path/type, JMX path, whether JMX was generated, JMeter image, CI mode, timestamps, and artifact paths.
- Covers YAML specs and existing JMX input.
- Keeps env-file paths and resolved secret values out of the manifest.
- Documents `run.json` in getting started and reports docs.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
