### PR TITLE
Import OpenAPI HTTP auth schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
 - Add latest-run metadata for default `loadwright run` result directories.
 - Add `loadwright compare` for Markdown comparisons between two `summary.json` files.
+- Import basic OpenAPI HTTP bearer/basic security schemes.
 
 ## 0.1.0 - 2026-04-25
 

--- a/docs/openapi-import.md
+++ b/docs/openapi-import.md
@@ -20,11 +20,13 @@ bin/loadwright import openapi openapi.yaml --base-url https://staging.example.co
 - Path parameters become Loadwright variables.
 - Query parameters become request query values.
 - JSON request bodies get a basic example body from examples or schema properties.
+- Global HTTP bearer/basic security requirements become Loadwright auth helpers.
 - The first `2xx` response becomes the expected status.
 
 ## Current Limitations
 
 - OpenAPI 3.x only.
 - `$ref` resolution is not implemented yet.
-- Security schemes are not imported yet.
+- Operation-level security overrides are not imported yet.
+- OAuth, API key, and non-HTTP security schemes are not imported yet.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/internal/openapi/importer.go
+++ b/internal/openapi/importer.go
@@ -16,10 +16,12 @@ type Options struct {
 }
 
 type Document struct {
-	OpenAPI string              `json:"openapi" yaml:"openapi"`
-	Info    Info                `json:"info" yaml:"info"`
-	Servers []Server            `json:"servers" yaml:"servers"`
-	Paths   map[string]PathItem `json:"paths" yaml:"paths"`
+	OpenAPI    string                `json:"openapi" yaml:"openapi"`
+	Info       Info                  `json:"info" yaml:"info"`
+	Servers    []Server              `json:"servers" yaml:"servers"`
+	Components Components            `json:"components" yaml:"components"`
+	Security   []SecurityRequirement `json:"security" yaml:"security"`
+	Paths      map[string]PathItem   `json:"paths" yaml:"paths"`
 }
 
 type Info struct {
@@ -70,6 +72,20 @@ type Example struct {
 }
 
 type Response struct{}
+
+type Components struct {
+	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes" yaml:"securitySchemes"`
+}
+
+type SecurityRequirement map[string][]string
+
+type SecurityScheme struct {
+	Type         string `json:"type" yaml:"type"`
+	Scheme       string `json:"scheme" yaml:"scheme"`
+	BearerFormat string `json:"bearerFormat" yaml:"bearerFormat"`
+	In           string `json:"in" yaml:"in"`
+	Name         string `json:"name" yaml:"name"`
+}
 
 type Schema struct {
 	Type       string            `json:"type" yaml:"type"`
@@ -132,6 +148,7 @@ func Import(doc Document, options Options) (*spec.Spec, error) {
 			P95MsLT:     &p95,
 		},
 	}
+	out.Auth = authFromSecurity(doc, out.Variables)
 
 	for _, path := range sortedPathKeys(doc.Paths) {
 		item := doc.Paths[path]
@@ -205,6 +222,45 @@ func requestFromOperation(method string, path string, operation *Operation, vari
 		request.Body = body
 	}
 	return request
+}
+
+func authFromSecurity(doc Document, variables map[string]string) spec.Auth {
+	for _, requirement := range doc.Security {
+		for schemeName := range requirement {
+			scheme, ok := doc.Components.SecuritySchemes[schemeName]
+			if !ok {
+				continue
+			}
+			auth := authFromSecurityScheme(scheme, variables)
+			if !auth.IsZero() {
+				return auth
+			}
+		}
+	}
+	return spec.Auth{}
+}
+
+func authFromSecurityScheme(scheme SecurityScheme, variables map[string]string) spec.Auth {
+	if !strings.EqualFold(strings.TrimSpace(scheme.Type), "http") {
+		return spec.Auth{}
+	}
+	switch strings.ToLower(strings.TrimSpace(scheme.Scheme)) {
+	case "bearer":
+		if _, exists := variables["api_token"]; !exists {
+			variables["api_token"] = "replace-me"
+		}
+		return spec.Auth{Type: "bearer", Token: "{{api_token}}"}
+	case "basic":
+		if _, exists := variables["basic_username"]; !exists {
+			variables["basic_username"] = "replace-me"
+		}
+		if _, exists := variables["basic_password"]; !exists {
+			variables["basic_password"] = "replace-me"
+		}
+		return spec.Auth{Type: "basic", Username: "{{basic_username}}", Password: "{{basic_password}}"}
+	default:
+		return spec.Auth{}
+	}
 }
 
 func parameterExample(parameter Parameter) string {

--- a/internal/openapi/importer_test.go
+++ b/internal/openapi/importer_test.go
@@ -131,6 +131,72 @@ func TestImportExamplesAndSchemaFallbacks(t *testing.T) {
 	}
 }
 
+func TestImportGlobalBearerSecurity(t *testing.T) {
+	imported, err := Import(Document{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "Bearer API"},
+		Components: Components{SecuritySchemes: map[string]SecurityScheme{
+			"bearerAuth": {Type: "http", Scheme: "bearer", BearerFormat: "JWT"},
+		}},
+		Security: []SecurityRequirement{{"bearerAuth": {}}},
+		Paths: map[string]PathItem{
+			"/secure": {Get: &Operation{Responses: map[string]Response{"200": {}}}},
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if imported.Auth.Type != "bearer" || imported.Auth.Token != "{{api_token}}" {
+		t.Fatalf("auth = %+v", imported.Auth)
+	}
+	if imported.Variables["api_token"] != "replace-me" {
+		t.Fatalf("api_token variable = %q", imported.Variables["api_token"])
+	}
+}
+
+func TestImportGlobalBasicSecurity(t *testing.T) {
+	imported, err := Import(Document{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "Basic API"},
+		Components: Components{SecuritySchemes: map[string]SecurityScheme{
+			"basicAuth": {Type: "http", Scheme: "basic"},
+		}},
+		Security: []SecurityRequirement{{"basicAuth": {}}},
+		Paths: map[string]PathItem{
+			"/secure": {Get: &Operation{Responses: map[string]Response{"200": {}}}},
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if imported.Auth.Type != "basic" || imported.Auth.Username != "{{basic_username}}" || imported.Auth.Password != "{{basic_password}}" {
+		t.Fatalf("auth = %+v", imported.Auth)
+	}
+	if imported.Variables["basic_username"] != "replace-me" || imported.Variables["basic_password"] != "replace-me" {
+		t.Fatalf("variables = %+v", imported.Variables)
+	}
+}
+
+func TestImportIgnoresUnsupportedSecuritySchemes(t *testing.T) {
+	imported, err := Import(Document{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "API Key API"},
+		Components: Components{SecuritySchemes: map[string]SecurityScheme{
+			"apiKey": {Type: "apiKey", In: "header", Name: "X-API-Key"},
+		}},
+		Security: []SecurityRequirement{{"apiKey": {}}},
+		Paths: map[string]PathItem{
+			"/secure": {Get: &Operation{Responses: map[string]Response{"200": {}}}},
+		},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	if !imported.Auth.IsZero() {
+		t.Fatalf("unsupported auth should not be imported: %+v", imported.Auth)
+	}
+}
+
 const petstoreLiteYAML = `openapi: 3.0.3
 info:
   title: Petstore Lite


### PR DESCRIPTION
Closes #15.\n\n## Summary\n- import global OpenAPI HTTP bearer/basic security requirements into Loadwright auth helpers\n- add placeholder variables for imported auth credentials\n- document supported auth imports and remaining limitations\n\n## Tests\n- go test ./...\n- go vet ./...\n- git diff --check\n- go build -o bin/loadwright ./cmd/loadwright