### PR TITLE
Import Postman form body fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a copy-paste GitHub Actions workflow example for downstream CI adoption.
 - Add latest-run metadata for default `loadwright run` result directories.
 - Add `loadwright compare` for Markdown comparisons between two `summary.json` files.
+- Import Postman urlencoded and text form-data bodies as starter bodies with warnings.
 
 ## 0.1.0 - 2026-04-25
 

--- a/docs/har-import.md
+++ b/docs/har-import.md
@@ -29,5 +29,6 @@ bin/loadwright import har capture.har --base-url https://staging.example.com -o 
 - Browser replay semantics are not reproduced.
 - Cookies are not imported.
 - File uploads and encoded/binary request bodies are skipped with warnings.
+- Current JMX generation renders imported flat form bodies as raw body content, so review generated form specs before CI use.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/postman-import.md
+++ b/docs/postman-import.md
@@ -20,15 +20,17 @@ bin/loadwright import postman collection.json --base-url https://staging.example
 - Collection variables become Loadwright variables.
 - Folders are included in request names.
 - Supported requests become Loadwright HTTP requests.
-- Method, path, query params, headers, and raw JSON/text bodies are imported.
+- Method, path, query params, headers, raw JSON/text bodies, urlencoded fields, and text form-data fields are imported.
 - Collection-level bearer/basic auth becomes global Loadwright auth.
 - Request-level bearer/basic auth becomes request auth.
 - Postman variables such as `{{base_url}}` remain reviewable in the YAML output.
+- Urlencoded and form-data fields are imported as flat starter bodies with warnings.
 
 ## Current Limitations
 
 - Postman Collection v2.1 JSON only.
 - Postman pre-request scripts and tests are not executed or translated.
-- Form-data, urlencoded, file, GraphQL, and advanced auth modes are reported as warnings and skipped where needed.
+- File uploads, GraphQL, and advanced auth modes are reported as warnings and skipped where needed.
+- Current JMX generation renders imported flat form bodies as raw body content, so review generated form specs before CI use.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -367,7 +367,13 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
       "name": "Upload",
       "request": {
         "method": "POST",
-        "body": {"mode": "formdata"},
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "title", "value": "avatar"},
+            {"key": "avatar", "type": "file", "src": "/tmp/avatar.png"}
+          ]
+        },
         "url": "{{base_url}}/upload"
       }
     }
@@ -387,10 +393,12 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "target: '{{base_url}}'") ||
 		!strings.Contains(string(data), "name: Create user") ||
-		!strings.Contains(string(data), "name: Ada") {
+		!strings.Contains(string(data), "name: Ada") ||
+		!strings.Contains(string(data), "title: avatar") {
 		t.Fatalf("unexpected imported spec: %s", data)
 	}
-	if !strings.Contains(stderr.String(), `warning: Upload: request body mode "formdata" is not imported yet`) {
+	if !strings.Contains(stderr.String(), `warning: Upload: form-data file field "avatar" was skipped`) ||
+		!strings.Contains(stderr.String(), "warning: Upload: form-data fields imported as a flat object starter body; review multipart encoding before CI use") {
 		t.Fatalf("expected warning, got stderr=%s", stderr.String())
 	}
 }

--- a/internal/postman/importer.go
+++ b/internal/postman/importer.go
@@ -133,9 +133,11 @@ type QueryParam struct {
 }
 
 type Body struct {
-	Mode    string      `json:"mode"`
-	Raw     string      `json:"raw"`
-	Options BodyOptions `json:"options"`
+	Mode       string      `json:"mode"`
+	Raw        string      `json:"raw"`
+	URLEncoded []FormParam `json:"urlencoded"`
+	FormData   []FormParam `json:"formdata"`
+	Options    BodyOptions `json:"options"`
 }
 
 type BodyOptions struct {
@@ -144,6 +146,14 @@ type BodyOptions struct {
 
 type RawBodyOptions struct {
 	Language string `json:"language"`
+}
+
+type FormParam struct {
+	Key      string `json:"key"`
+	Value    any    `json:"value"`
+	Type     string `json:"type"`
+	Disabled bool   `json:"disabled"`
+	Src      any    `json:"src"`
 }
 
 type Auth struct {
@@ -449,8 +459,63 @@ func bodyFromPostman(body Body, headers map[string]string) (any, []string) {
 			return raw, []string{"raw body looked like JSON but could not be parsed; imported as string"}
 		}
 		return raw, nil
+	case "urlencoded":
+		form := formParamsBody(body.URLEncoded)
+		if len(form) == 0 {
+			return nil, nil
+		}
+		return form, []string{"urlencoded body imported as a flat object starter body; review encoding before CI use"}
+	case "formdata":
+		form, warnings := formDataBody(body.FormData)
+		if len(form) == 0 {
+			return nil, warnings
+		}
+		warnings = append(warnings, "form-data fields imported as a flat object starter body; review multipart encoding before CI use")
+		return form, warnings
 	default:
 		return nil, []string{fmt.Sprintf("request body mode %q is not imported yet", mode)}
+	}
+}
+
+func formParamsBody(params []FormParam) map[string]any {
+	out := map[string]any{}
+	for _, param := range params {
+		key := strings.TrimSpace(param.Key)
+		if param.Disabled || key == "" {
+			continue
+		}
+		out[key] = stringify(param.Value)
+	}
+	return out
+}
+
+func formDataBody(params []FormParam) (map[string]any, []string) {
+	out := map[string]any{}
+	var warnings []string
+	for _, param := range params {
+		key := strings.TrimSpace(param.Key)
+		if param.Disabled || key == "" {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(param.Type), "file") || hasFormFileSource(param.Src) {
+			warnings = append(warnings, fmt.Sprintf("form-data file field %q was skipped", key))
+			continue
+		}
+		out[key] = stringify(param.Value)
+	}
+	return out, warnings
+}
+
+func hasFormFileSource(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case []any:
+		return len(typed) > 0
+	default:
+		return true
 	}
 }
 

--- a/internal/postman/importer_test.go
+++ b/internal/postman/importer_test.go
@@ -107,6 +107,81 @@ func TestImportRequestLevelBasicAuth(t *testing.T) {
 	}
 }
 
+func TestImportURLEncodedBodyAsStarterBody(t *testing.T) {
+	result, err := Import(Collection{
+		Info: Info{Name: "Forms"},
+		Items: []Item{{
+			Name: "Login",
+			Request: Request{
+				Set:    true,
+				Method: "POST",
+				URL:    URL{Raw: "https://api.example.com/login"},
+				Body: Body{
+					Mode: "urlencoded",
+					URLEncoded: []FormParam{
+						{Key: "username", Value: "demo"},
+						{Key: "password", Value: "secret"},
+						{Key: "ignored", Value: "nope", Disabled: true},
+					},
+				},
+			},
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	body := result.Spec.Requests[0].Body.(map[string]any)
+	if body["username"] != "demo" || body["password"] != "secret" {
+		t.Fatalf("body = %+v", body)
+	}
+	if _, exists := body["ignored"]; exists {
+		t.Fatalf("disabled form param imported: %+v", body)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "Login: urlencoded body imported as a flat object starter body; review encoding before CI use") {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+}
+
+func TestImportFormDataBodySkipsFileFields(t *testing.T) {
+	result, err := Import(Collection{
+		Info: Info{Name: "Multipart"},
+		Items: []Item{{
+			Name: "Upload",
+			Request: Request{
+				Set:    true,
+				Method: "POST",
+				URL:    URL{Raw: "https://api.example.com/upload"},
+				Body: Body{
+					Mode: "formdata",
+					FormData: []FormParam{
+						{Key: "title", Value: "avatar"},
+						{Key: "avatar", Type: "file", Src: "/tmp/avatar.png"},
+					},
+				},
+			},
+		}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	body := result.Spec.Requests[0].Body.(map[string]any)
+	if body["title"] != "avatar" {
+		t.Fatalf("body = %+v", body)
+	}
+	if _, exists := body["avatar"]; exists {
+		t.Fatalf("file field imported: %+v", body)
+	}
+	joined := strings.Join(result.Warnings, "\n")
+	for _, expected := range []string{
+		`Upload: form-data file field "avatar" was skipped`,
+		"Upload: form-data fields imported as a flat object starter body; review multipart encoding before CI use",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("missing warning %q in %+v", expected, result.Warnings)
+		}
+	}
+}
+
 func TestImportWarnsForUnsupportedFeatures(t *testing.T) {
 	result, err := Import(Collection{
 		Info: Info{Name: "Unsupported"},


### PR DESCRIPTION
Closes #16.\n\n## Summary\n- import Postman urlencoded fields as flat starter bodies with review warnings\n- import text form-data fields and skip file form-data fields with warnings\n- update CLI/unit coverage and importer docs for current JMX form-body behavior\n\n## Tests\n- go test ./...\n- go vet ./...\n- git diff --check\n- go build -o bin/loadwright ./cmd/loadwright