### PR TITLE
Add urlencoded form body support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add per-run `run.json` metadata manifests.
 - Import basic OpenAPI HTTP bearer/basic security schemes.
 - Import Postman urlencoded and text form-data bodies as starter bodies with warnings.
+- Add first-class `body_json`, `body_text`, and runnable urlencoded `body_form` request bodies.
 
 ## 0.1.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is not a new load-testing engine. It is a small automation layer that keeps J
 
 Loadwright is at `v0.1.0`. It is usable for HTTP API load-test workflows and CI smoke/performance checks, but the public API and YAML spec may still evolve before `v1.0.0`.
 
-The current development scope is intentionally focused: HTTP requests, Dockerized JMeter execution, OpenAPI/Postman/HAR bootstrapping, CSV data, thresholds, and reports. WebSocket support, plugin management, distributed runners, and AI-assisted workflows are planned later.
+The current development scope is intentionally focused: HTTP requests, JSON/text/form bodies, Dockerized JMeter execution, OpenAPI/Postman/HAR bootstrapping, CSV data, thresholds, and reports. WebSocket support, plugin management, distributed runners, and AI-assisted workflows are planned later.
 
 ## Why This Exists
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,6 +26,14 @@ bin/loadwright run examples/api/post-json.yaml --ci
 
 Demonstrates JSON request bodies and custom headers.
 
+## Urlencoded Form
+
+```bash
+bin/loadwright run examples/api/form-urlencoded.yaml --ci
+```
+
+Demonstrates `application/x-www-form-urlencoded` request bodies with `body_form`.
+
 ## Checkout Flow
 
 ```bash

--- a/docs/har-import.md
+++ b/docs/har-import.md
@@ -20,7 +20,7 @@ bin/loadwright import har capture.har --base-url https://staging.example.com -o 
 - The first request origin becomes `target` unless `--base-url` is provided.
 - Supported requests become Loadwright HTTP requests.
 - Method, path, query params, headers, and JSON/text request bodies are imported.
-- Form params are imported as a flat starter body with a warning.
+- Form params are imported as runnable `body_form` specs.
 - Unsupported or lossy capture details are reported as warnings.
 
 ## Current Limitations
@@ -29,6 +29,6 @@ bin/loadwright import har capture.har --base-url https://staging.example.com -o 
 - Browser replay semantics are not reproduced.
 - Cookies are not imported.
 - File uploads and encoded/binary request bodies are skipped with warnings.
-- Current JMX generation renders imported flat form bodies as raw body content, so review generated form specs before CI use.
+- Multipart form-data is not rendered as multipart JMeter requests yet.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,6 +7,7 @@ Loadwright `v0.1.0` is intentionally focused on HTTP API load-test workflows.
 - YAML specs for HTTP API requests.
 - GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS requests.
 - Query params, headers, JSON/string bodies, expected HTTP status assertions.
+- Urlencoded form bodies.
 - Basic and bearer auth helpers.
 - Environment files and simple variable substitution.
 - CSV data sources.
@@ -24,6 +25,7 @@ Loadwright `v0.1.0` is intentionally focused on HTTP API load-test workflows.
 - Distributed load generation across multiple workers.
 - Historical trend storage.
 - Browser-level performance testing.
+- Multipart form-data request rendering.
 - AI-assisted spec generation or result explanation.
 
 ## Compatibility Boundary

--- a/docs/postman-import.md
+++ b/docs/postman-import.md
@@ -24,13 +24,14 @@ bin/loadwright import postman collection.json --base-url https://staging.example
 - Collection-level bearer/basic auth becomes global Loadwright auth.
 - Request-level bearer/basic auth becomes request auth.
 - Postman variables such as `{{base_url}}` remain reviewable in the YAML output.
-- Urlencoded and form-data fields are imported as flat starter bodies with warnings.
+- Urlencoded fields become runnable `body_form` specs.
+- Text form-data fields are imported as flat starter bodies with warnings.
 
 ## Current Limitations
 
 - Postman Collection v2.1 JSON only.
 - Postman pre-request scripts and tests are not executed or translated.
 - File uploads, GraphQL, and advanced auth modes are reported as warnings and skipped where needed.
-- Current JMX generation renders imported flat form bodies as raw body content, so review generated form specs before CI use.
+- Multipart form-data is not rendered as multipart JMeter requests yet, so review generated form-data starter specs before CI use.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -35,6 +35,46 @@ thresholds:
 - `requests`: required list of HTTP requests.
 - `thresholds`: optional CI pass/fail rules.
 
+## Request Bodies
+
+Use one body field per request.
+
+Legacy `body` remains supported and is rendered as raw body content. Prefer the explicit fields for new specs:
+
+JSON body:
+
+```yaml
+requests:
+  - method: POST
+    path: /users
+    headers:
+      content-type: application/json
+    body_json:
+      name: Ada
+```
+
+Text body:
+
+```yaml
+requests:
+  - method: POST
+    path: /events
+    body_text: plain text payload
+```
+
+Urlencoded form body:
+
+```yaml
+requests:
+  - method: POST
+    path: /login
+    body_form:
+      username: demo
+      password: secret
+```
+
+`body_form` compiles to JMeter HTTP arguments with `HTTPSampler.postBodyRaw=false` and adds `Content-Type: application/x-www-form-urlencoded` when no content type header is already set.
+
 ## Variables
 
 Variables can be referenced with `{{name}}`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,9 +46,9 @@ bin/loadwright report results/manual-smoke/results.jtl --out-dir /tmp/loadwright
 ## Current Coverage Focus
 
 - Spec validation, defaults, variables, env files, auth, and timeout behavior.
-- JMX rendering, including headers, query params, JSON bodies, assertions, duration loads, and timeouts.
+- JMX rendering, including headers, query params, JSON bodies, urlencoded form bodies, assertions, duration loads, and timeouts.
 - JTL parsing, percentile summaries, threshold pass/fail, and report artifacts.
 - JUnit report generation for CI integrations.
 - CLI parsing, non-Docker command flows, and end-to-end run/report generation with a Docker shim.
-- OpenAPI import for YAML, JSON, path/query params, request bodies, and error cases.
+- OpenAPI/Postman/HAR import for YAML, JSON, path/query params, request bodies, and error cases.
 - Runtime helper behavior for doctor/version parsing.

--- a/examples/api/form-urlencoded.yaml
+++ b/examples/api/form-urlencoded.yaml
@@ -1,0 +1,18 @@
+name: form-urlencoded-example
+target: https://httpbin.org
+load:
+  users: 2
+  ramp_up: 5s
+  loops: 2
+requests:
+  - name: submit form
+    method: POST
+    path: /post
+    body_form:
+      username: demo
+      password: secret
+    expect:
+      status: 200
+thresholds:
+  error_rate_lt: 1
+  p95_ms_lt: 3000

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -376,6 +376,20 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
         },
         "url": "{{base_url}}/upload"
       }
+    },
+    {
+      "name": "Login",
+      "request": {
+        "method": "POST",
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {"key": "username", "value": "demo"},
+            {"key": "password", "value": "secret"}
+          ]
+        },
+        "url": "{{base_url}}/login"
+      }
     }
   ]
 }`
@@ -394,7 +408,9 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
 	if !strings.Contains(string(data), "target: '{{base_url}}'") ||
 		!strings.Contains(string(data), "name: Create user") ||
 		!strings.Contains(string(data), "name: Ada") ||
-		!strings.Contains(string(data), "title: avatar") {
+		!strings.Contains(string(data), "title: avatar") ||
+		!strings.Contains(string(data), "body_form:") ||
+		!strings.Contains(string(data), "username: demo") {
 		t.Fatalf("unexpected imported spec: %s", data)
 	}
 	if !strings.Contains(stderr.String(), `warning: Upload: form-data file field "avatar" was skipped`) ||

--- a/internal/har/importer.go
+++ b/internal/har/importer.go
@@ -166,13 +166,16 @@ func requestFromHAR(index int, harRequest Request) (spec.Request, string, []stri
 	warnings = append(warnings, bodyWarnings...)
 
 	return spec.Request{
-		Name:    name,
-		Method:  method,
-		Path:    requestPath,
-		Headers: headers,
-		Query:   query,
-		Body:    body,
-		Expect:  spec.Expect{Status: 200},
+		Name:     name,
+		Method:   method,
+		Path:     requestPath,
+		Headers:  headers,
+		Query:    query,
+		Body:     body.Legacy,
+		BodyJSON: body.JSON,
+		BodyText: body.Text,
+		BodyForm: body.Form,
+		Expect:   spec.Expect{Status: 200},
 	}, target, warnings, true
 }
 
@@ -223,24 +226,31 @@ func headersFromHAR(requestName string, headers []NameValue) (map[string]string,
 	return out, warnings
 }
 
-func bodyFromHAR(requestName string, postData *PostData, headers map[string]string) (any, []string) {
+type requestBody struct {
+	Legacy any
+	JSON   any
+	Text   string
+	Form   map[string]string
+}
+
+func bodyFromHAR(requestName string, postData *PostData, headers map[string]string) (requestBody, []string) {
 	if postData == nil {
-		return nil, nil
+		return requestBody{}, nil
 	}
 	if strings.TrimSpace(postData.Encoding) != "" && !strings.EqualFold(postData.Encoding, "utf-8") {
-		return nil, []string{fmt.Sprintf("%s request body uses %s encoding and was skipped", requestName, postData.Encoding)}
+		return requestBody{}, []string{fmt.Sprintf("%s request body uses %s encoding and was skipped", requestName, postData.Encoding)}
 	}
 	if len(postData.Params) > 0 {
 		for _, param := range postData.Params {
 			if strings.TrimSpace(param.FileName) != "" {
-				return nil, []string{fmt.Sprintf("%s has file upload form data; body was skipped", requestName)}
+				return requestBody{}, []string{fmt.Sprintf("%s has file upload form data; body was skipped", requestName)}
 			}
 		}
-		return paramsBody(postData.Params), []string{fmt.Sprintf("%s has form params; imported as a flat object starter body", requestName)}
+		return requestBody{Form: paramsBody(postData.Params)}, nil
 	}
 	text := strings.TrimSpace(postData.Text)
 	if text == "" {
-		return nil, nil
+		return requestBody{}, nil
 	}
 	if shouldParseJSON(text, postData.MimeType, headers) {
 		var parsed any
@@ -248,15 +258,15 @@ func bodyFromHAR(requestName string, postData *PostData, headers map[string]stri
 			if !hasHeader(headers, "content-type") {
 				headers["Content-Type"] = "application/json"
 			}
-			return parsed, nil
+			return requestBody{JSON: parsed}, nil
 		}
-		return text, []string{fmt.Sprintf("%s body looked like JSON but could not be parsed; imported as string", requestName)}
+		return requestBody{Text: text}, []string{fmt.Sprintf("%s body looked like JSON but could not be parsed; imported as string", requestName)}
 	}
-	return text, nil
+	return requestBody{Text: text}, nil
 }
 
-func paramsBody(params []PostParam) map[string]any {
-	out := map[string]any{}
+func paramsBody(params []PostParam) map[string]string {
+	out := map[string]string{}
 	for _, param := range params {
 		key := strings.TrimSpace(param.Name)
 		if key == "" {

--- a/internal/har/importer_test.go
+++ b/internal/har/importer_test.go
@@ -36,9 +36,9 @@ func TestImportHARBasics(t *testing.T) {
 	if create.Name != "POST /v1/users" || create.Method != "POST" || create.Path != "/v1/users" {
 		t.Fatalf("unexpected create request: %+v", create)
 	}
-	body := create.Body.(map[string]any)
+	body := create.BodyJSON.(map[string]any)
 	if body["name"] != "Ada" || body["role"] != "admin" {
-		t.Fatalf("body = %+v", body)
+		t.Fatalf("body_json = %+v", body)
 	}
 	if create.Headers["Content-Type"] != "application/json" {
 		t.Fatalf("headers = %+v", create.Headers)
@@ -91,7 +91,7 @@ func TestImportBaseURLOverrideAndWarnings(t *testing.T) {
 	}
 }
 
-func TestImportFormParamsAsStarterBody(t *testing.T) {
+func TestImportFormParamsAsFormBody(t *testing.T) {
 	result, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
 		Method: "POST",
 		URL:    "https://api.example.com/login",
@@ -103,11 +103,11 @@ func TestImportFormParamsAsStarterBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Import() error = %v", err)
 	}
-	body := result.Spec.Requests[0].Body.(map[string]any)
-	if body["username"] != "demo" || body["password"] != "secret" {
-		t.Fatalf("body = %+v", body)
+	bodyForm := result.Spec.Requests[0].BodyForm
+	if bodyForm["username"] != "demo" || bodyForm["password"] != "secret" {
+		t.Fatalf("body_form = %+v", bodyForm)
 	}
-	if !strings.Contains(strings.Join(result.Warnings, "\n"), "POST /login has form params; imported as a flat object starter body") {
+	if len(result.Warnings) != 0 {
 		t.Fatalf("warnings = %+v", result.Warnings)
 	}
 }

--- a/internal/jmx/generator.go
+++ b/internal/jmx/generator.go
@@ -113,7 +113,7 @@ func writeThreadGroup(b *strings.Builder, s *spec.Spec) {
 func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 	target, _ := url.Parse(s.Target)
 	fmt.Fprintf(b, `        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="%s" enabled="true">`+"\n", esc(r.Name))
-	body := bodyString(r.Body)
+	body := rawBodyString(r)
 	if body != "" {
 		b.WriteString("          <boolProp name=\"HTTPSampler.postBodyRaw\">true</boolProp>\n")
 	} else {
@@ -127,6 +127,8 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 		fmt.Fprintf(b, "                <stringProp name=\"Argument.value\">%s</stringProp>\n", esc(body))
 		b.WriteString("                <stringProp name=\"Argument.metadata\">=</stringProp>\n")
 		b.WriteString("              </elementProp>\n")
+	} else if len(r.BodyForm) > 0 {
+		writeFormArguments(b, r.BodyForm)
 	} else {
 		writeQueryArguments(b, r.Query)
 	}
@@ -151,8 +153,9 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 	fmt.Fprintf(b, "          <stringProp name=\"HTTPSampler.response_timeout\">%s</stringProp>\n", timeoutMS)
 	b.WriteString("        </HTTPSamplerProxy>\n")
 	b.WriteString("        <hashTree>\n")
-	if len(r.Headers) > 0 {
-		writeHeaders(b, r.Headers)
+	headers := requestHeaders(r)
+	if len(headers) > 0 {
+		writeHeaders(b, headers)
 	}
 	if r.Expect.Status > 0 {
 		writeStatusAssertion(b, r.Expect.Status)
@@ -167,6 +170,19 @@ func writeQueryArguments(b *strings.Builder, query map[string]string) {
 		b.WriteString("                <boolProp name=\"HTTPArgument.always_encode\">true</boolProp>\n")
 		fmt.Fprintf(b, "                <stringProp name=\"Argument.name\">%s</stringProp>\n", esc(key))
 		fmt.Fprintf(b, "                <stringProp name=\"Argument.value\">%s</stringProp>\n", esc(query[key]))
+		b.WriteString("                <stringProp name=\"Argument.metadata\">=</stringProp>\n")
+		b.WriteString("                <boolProp name=\"HTTPArgument.use_equals\">true</boolProp>\n")
+		b.WriteString("              </elementProp>\n")
+	}
+}
+
+func writeFormArguments(b *strings.Builder, fields map[string]string) {
+	keys := sortedKeys(fields)
+	for _, key := range keys {
+		fmt.Fprintf(b, "              <elementProp name=\"%s\" elementType=\"HTTPArgument\">\n", esc(key))
+		b.WriteString("                <boolProp name=\"HTTPArgument.always_encode\">true</boolProp>\n")
+		fmt.Fprintf(b, "                <stringProp name=\"Argument.name\">%s</stringProp>\n", esc(key))
+		fmt.Fprintf(b, "                <stringProp name=\"Argument.value\">%s</stringProp>\n", esc(fields[key]))
 		b.WriteString("                <stringProp name=\"Argument.metadata\">=</stringProp>\n")
 		b.WriteString("                <boolProp name=\"HTTPArgument.use_equals\">true</boolProp>\n")
 		b.WriteString("              </elementProp>\n")
@@ -198,6 +214,16 @@ func writeStatusAssertion(b *strings.Builder, status int) {
 	b.WriteString("            <intProp name=\"Assertion.test_type\">8</intProp>\n")
 	b.WriteString("          </ResponseAssertion>\n")
 	b.WriteString("          <hashTree/>\n")
+}
+
+func rawBodyString(r spec.Request) string {
+	if r.BodyText != "" {
+		return r.BodyText
+	}
+	if r.BodyJSON != nil {
+		return bodyString(r.BodyJSON)
+	}
+	return bodyString(r.Body)
 }
 
 func bodyString(body any) string {
@@ -237,6 +263,27 @@ func jsonable(value any) any {
 	default:
 		return value
 	}
+}
+
+func requestHeaders(r spec.Request) map[string]string {
+	if len(r.BodyForm) == 0 || hasHeader(r.Headers, "content-type") {
+		return r.Headers
+	}
+	headers := map[string]string{}
+	for key, value := range r.Headers {
+		headers[key] = value
+	}
+	headers["Content-Type"] = "application/x-www-form-urlencoded"
+	return headers
+}
+
+func hasHeader(headers map[string]string, name string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func esc(value string) string {

--- a/internal/jmx/generator_test.go
+++ b/internal/jmx/generator_test.go
@@ -126,6 +126,40 @@ func TestRenderQueryParamsAndJSONBody(t *testing.T) {
 	}
 }
 
+func TestRenderFormBodyArguments(t *testing.T) {
+	loops := 1
+	loaded := &spec.Spec{
+		Name:   "form body",
+		Target: "https://api.example.com",
+		Load:   spec.Load{Users: 1, RampUp: spec.Duration{Seconds: 1, Set: true}, Loops: &loops},
+		Requests: []spec.Request{{
+			Name:   "login",
+			Method: "POST",
+			Path:   "/login",
+			BodyForm: map[string]string{
+				"password": "secret",
+				"username": "demo",
+			},
+		}},
+	}
+	rendered := Render(loaded)
+	for _, expected := range []string{
+		`<boolProp name="HTTPSampler.postBodyRaw">false</boolProp>`,
+		`<elementProp name="password" elementType="HTTPArgument">`,
+		`<stringProp name="Argument.name">username</stringProp>`,
+		`<stringProp name="Argument.value">demo</stringProp>`,
+		`<stringProp name="Header.name">Content-Type</stringProp>`,
+		`<stringProp name="Header.value">application/x-www-form-urlencoded</stringProp>`,
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("form JMX missing %q\n%s", expected, rendered)
+		}
+	}
+	if strings.Contains(rendered, `HTTPSampler.postBodyRaw">true`) || strings.Contains(rendered, `{&#34;username&#34;`) {
+		t.Fatalf("form body rendered as raw JSON\n%s", rendered)
+	}
+}
+
 func TestRenderDurationBasedLoad(t *testing.T) {
 	loaded := &spec.Spec{
 		Name:   "duration load",

--- a/internal/openapi/importer.go
+++ b/internal/openapi/importer.go
@@ -219,7 +219,7 @@ func requestFromOperation(method string, path string, operation *Operation, vari
 	}
 	if body, ok := requestBodyExample(operation.RequestBody); ok {
 		request.Headers = map[string]string{"content-type": "application/json"}
-		request.Body = body
+		request.BodyJSON = body
 	}
 	return request
 }

--- a/internal/openapi/importer_test.go
+++ b/internal/openapi/importer_test.go
@@ -40,9 +40,9 @@ func TestImportYAMLOperations(t *testing.T) {
 	if post.Name != "createPet" || post.Method != "POST" || post.Expect.Status != 201 {
 		t.Fatalf("unexpected POST request: %+v", post)
 	}
-	body := post.Body.(map[string]any)
+	body := post.BodyJSON.(map[string]any)
 	if body["name"] != "example" || body["tag"] != "example" {
-		t.Fatalf("unexpected body: %+v", body)
+		t.Fatalf("unexpected body_json: %+v", body)
 	}
 }
 
@@ -121,7 +121,7 @@ func TestImportExamplesAndSchemaFallbacks(t *testing.T) {
 	for index, request := range imported.Requests {
 		requests[request.Name] = index
 	}
-	body := imported.Requests[requests["POST /items"]].Body.(map[string]any)
+	body := imported.Requests[requests["POST /items"]].BodyJSON.(map[string]any)
 	if body["name"] != "from-example" {
 		t.Fatalf("example body not used: %+v", body)
 	}

--- a/internal/postman/importer.go
+++ b/internal/postman/importer.go
@@ -297,14 +297,17 @@ func requestFromPostman(item Item, folders []string, collectionAuth *Auth) (spec
 	}
 
 	return spec.Request{
-		Name:    requestName,
-		Method:  method,
-		Path:    requestPath,
-		Headers: headers,
-		Query:   query,
-		Body:    body,
-		Auth:    requestAuth,
-		Expect:  spec.Expect{Status: 200},
+		Name:     requestName,
+		Method:   method,
+		Path:     requestPath,
+		Headers:  headers,
+		Query:    query,
+		Body:     body.Legacy,
+		BodyJSON: body.JSON,
+		BodyText: body.Text,
+		BodyForm: body.Form,
+		Auth:     requestAuth,
+		Expect:   spec.Expect{Status: 200},
 	}, target, warnings, true
 }
 
@@ -438,15 +441,22 @@ func headersFromPostman(headers []Header) map[string]string {
 	return out
 }
 
-func bodyFromPostman(body Body, headers map[string]string) (any, []string) {
+type requestBody struct {
+	Legacy any
+	JSON   any
+	Text   string
+	Form   map[string]string
+}
+
+func bodyFromPostman(body Body, headers map[string]string) (requestBody, []string) {
 	mode := strings.ToLower(strings.TrimSpace(body.Mode))
 	switch mode {
 	case "":
-		return nil, nil
+		return requestBody{}, nil
 	case "raw":
 		raw := strings.TrimSpace(body.Raw)
 		if raw == "" {
-			return nil, nil
+			return requestBody{}, nil
 		}
 		if shouldParseJSON(raw, body, headers) {
 			var parsed any
@@ -454,31 +464,31 @@ func bodyFromPostman(body Body, headers map[string]string) (any, []string) {
 				if !hasHeader(headers, "content-type") {
 					headers["Content-Type"] = "application/json"
 				}
-				return parsed, nil
+				return requestBody{JSON: parsed}, nil
 			}
-			return raw, []string{"raw body looked like JSON but could not be parsed; imported as string"}
+			return requestBody{Text: raw}, []string{"raw body looked like JSON but could not be parsed; imported as string"}
 		}
-		return raw, nil
+		return requestBody{Text: raw}, nil
 	case "urlencoded":
 		form := formParamsBody(body.URLEncoded)
 		if len(form) == 0 {
-			return nil, nil
+			return requestBody{}, nil
 		}
-		return form, []string{"urlencoded body imported as a flat object starter body; review encoding before CI use"}
+		return requestBody{Form: form}, nil
 	case "formdata":
 		form, warnings := formDataBody(body.FormData)
 		if len(form) == 0 {
-			return nil, warnings
+			return requestBody{}, warnings
 		}
 		warnings = append(warnings, "form-data fields imported as a flat object starter body; review multipart encoding before CI use")
-		return form, warnings
+		return requestBody{Legacy: form}, warnings
 	default:
-		return nil, []string{fmt.Sprintf("request body mode %q is not imported yet", mode)}
+		return requestBody{}, []string{fmt.Sprintf("request body mode %q is not imported yet", mode)}
 	}
 }
 
-func formParamsBody(params []FormParam) map[string]any {
-	out := map[string]any{}
+func formParamsBody(params []FormParam) map[string]string {
+	out := map[string]string{}
 	for _, param := range params {
 		key := strings.TrimSpace(param.Key)
 		if param.Disabled || key == "" {

--- a/internal/postman/importer_test.go
+++ b/internal/postman/importer_test.go
@@ -42,9 +42,9 @@ func TestImportCollectionBasics(t *testing.T) {
 	if create.Method != "POST" || create.Path != "/v1/users" {
 		t.Fatalf("unexpected create request: %+v", create)
 	}
-	body := create.Body.(map[string]any)
+	body := create.BodyJSON.(map[string]any)
 	if body["name"] != "Ada" || body["role"] != "admin" {
-		t.Fatalf("body = %+v", body)
+		t.Fatalf("body_json = %+v", body)
 	}
 	if create.Headers["Content-Type"] != "application/json" {
 		t.Fatalf("headers = %+v", create.Headers)
@@ -107,7 +107,7 @@ func TestImportRequestLevelBasicAuth(t *testing.T) {
 	}
 }
 
-func TestImportURLEncodedBodyAsStarterBody(t *testing.T) {
+func TestImportURLEncodedBodyAsFormBody(t *testing.T) {
 	result, err := Import(Collection{
 		Info: Info{Name: "Forms"},
 		Items: []Item{{
@@ -130,14 +130,14 @@ func TestImportURLEncodedBodyAsStarterBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Import() error = %v", err)
 	}
-	body := result.Spec.Requests[0].Body.(map[string]any)
-	if body["username"] != "demo" || body["password"] != "secret" {
-		t.Fatalf("body = %+v", body)
+	bodyForm := result.Spec.Requests[0].BodyForm
+	if bodyForm["username"] != "demo" || bodyForm["password"] != "secret" {
+		t.Fatalf("body_form = %+v", bodyForm)
 	}
-	if _, exists := body["ignored"]; exists {
-		t.Fatalf("disabled form param imported: %+v", body)
+	if _, exists := bodyForm["ignored"]; exists {
+		t.Fatalf("disabled form param imported: %+v", bodyForm)
 	}
-	if !strings.Contains(strings.Join(result.Warnings, "\n"), "Login: urlencoded body imported as a flat object starter body; review encoding before CI use") {
+	if len(result.Warnings) != 0 {
 		t.Fatalf("warnings = %+v", result.Warnings)
 	}
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -114,15 +114,18 @@ type DataSet struct {
 }
 
 type Request struct {
-	Name    string            `yaml:"name"`
-	Method  string            `yaml:"method"`
-	Path    string            `yaml:"path"`
-	Headers map[string]string `yaml:"headers,omitempty"`
-	Query   map[string]string `yaml:"query,omitempty"`
-	Body    any               `yaml:"body,omitempty"`
-	Auth    Auth              `yaml:"auth,omitempty"`
-	Timeout Duration          `yaml:"timeout,omitempty"`
-	Expect  Expect            `yaml:"expect"`
+	Name     string            `yaml:"name"`
+	Method   string            `yaml:"method"`
+	Path     string            `yaml:"path"`
+	Headers  map[string]string `yaml:"headers,omitempty"`
+	Query    map[string]string `yaml:"query,omitempty"`
+	Body     any               `yaml:"body,omitempty"`
+	BodyJSON any               `yaml:"body_json,omitempty"`
+	BodyText string            `yaml:"body_text,omitempty"`
+	BodyForm map[string]string `yaml:"body_form,omitempty"`
+	Auth     Auth              `yaml:"auth,omitempty"`
+	Timeout  Duration          `yaml:"timeout,omitempty"`
+	Expect   Expect            `yaml:"expect"`
 }
 
 type Auth struct {
@@ -268,8 +271,39 @@ func (r *Request) NormalizeAndValidate(index int) error {
 	if r.Query == nil {
 		r.Query = map[string]string{}
 	}
+	if r.BodyForm == nil {
+		r.BodyForm = map[string]string{}
+	}
+	if err := r.validateBodyFields(index); err != nil {
+		return err
+	}
 	if err := r.Auth.NormalizeAndValidate(fmt.Sprintf("requests[%d].auth", index)); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (r *Request) validateBodyFields(index int) error {
+	var fields []string
+	if r.Body != nil {
+		fields = append(fields, "body")
+	}
+	if r.BodyJSON != nil {
+		fields = append(fields, "body_json")
+	}
+	if strings.TrimSpace(r.BodyText) != "" {
+		fields = append(fields, "body_text")
+	}
+	if len(r.BodyForm) > 0 {
+		fields = append(fields, "body_form")
+		for key := range r.BodyForm {
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("requests[%d].body_form contains an empty field name", index)
+			}
+		}
+	}
+	if len(fields) > 1 {
+		return fmt.Errorf("requests[%d] must set only one body field: %s", index, strings.Join(fields, ", "))
 	}
 	return nil
 }
@@ -410,6 +444,18 @@ func renderRequest(request Request, vars map[string]string, index int) (Request,
 	out.Body, err = renderAny(request.Body, vars)
 	if err != nil {
 		return Request{}, fmt.Errorf("requests[%d].body: %w", index, err)
+	}
+	out.BodyJSON, err = renderAny(request.BodyJSON, vars)
+	if err != nil {
+		return Request{}, fmt.Errorf("requests[%d].body_json: %w", index, err)
+	}
+	out.BodyText, err = renderString(request.BodyText, vars)
+	if err != nil {
+		return Request{}, fmt.Errorf("requests[%d].body_text: %w", index, err)
+	}
+	out.BodyForm, err = renderStringMap(request.BodyForm, vars)
+	if err != nil {
+		return Request{}, fmt.Errorf("requests[%d].body_form: %w", index, err)
 	}
 	out.Auth, err = renderAuth(request.Auth, vars, fmt.Sprintf("requests[%d].auth", index))
 	if err != nil {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -211,6 +211,56 @@ thresholds:
 	}
 }
 
+func TestLoadFileParsesExplicitBodyShapes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.yaml")
+	yaml := `name: body-shapes
+target: https://example.com
+requests:
+  - method: POST
+    path: /json
+    body_json:
+      ok: true
+  - method: POST
+    path: /text
+    body_text: hello
+  - method: POST
+    path: /form
+    body_form:
+      username: demo
+      password: secret
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if loaded.Requests[0].BodyJSON == nil {
+		t.Fatalf("body_json not parsed: %+v", loaded.Requests[0])
+	}
+	if loaded.Requests[1].BodyText != "hello" {
+		t.Fatalf("body_text = %q", loaded.Requests[1].BodyText)
+	}
+	if loaded.Requests[2].BodyForm["username"] != "demo" || loaded.Requests[2].BodyForm["password"] != "secret" {
+		t.Fatalf("body_form = %+v", loaded.Requests[2].BodyForm)
+	}
+}
+
+func TestRequestRejectsMultipleBodyShapes(t *testing.T) {
+	raw := Request{
+		Method:   "POST",
+		Path:     "/submit",
+		Body:     map[string]any{"legacy": true},
+		BodyForm: map[string]string{"username": "demo"},
+	}
+	err := raw.NormalizeAndValidate(0)
+	if err == nil || !strings.Contains(err.Error(), "must set only one body field") {
+		t.Fatalf("NormalizeAndValidate() error = %v", err)
+	}
+}
+
 func TestResolveVariablesEnvAndBearerAuth(t *testing.T) {
 	raw := Spec{
 		Name:   "{{service}} smoke",
@@ -250,19 +300,18 @@ func TestResolvePreservesJMeterRuntimeVariables(t *testing.T) {
 		Name:   "csv",
 		Target: "https://example.com",
 		Requests: []Request{{
-			Path: "/login",
-			Body: map[string]any{
-				"username": "${username}",
-			},
+			Path:     "/login",
+			BodyForm: map[string]string{"username": "${username}", "password": "{{password}}"},
 		}},
+		Variables: map[string]string{"password": "secret"},
 	}
 	resolved, err := raw.Resolve(nil)
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
-	body := resolved.Requests[0].Body.(map[string]any)
-	if body["username"] != "${username}" {
-		t.Fatalf("runtime variable was not preserved: %+v", body)
+	bodyForm := resolved.Requests[0].BodyForm
+	if bodyForm["username"] != "${username}" || bodyForm["password"] != "secret" {
+		t.Fatalf("body_form not resolved correctly: %+v", bodyForm)
 	}
 }
 


### PR DESCRIPTION
Closes #21.

## Summary

- Add explicit request body fields: `body_json`, `body_text`, and `body_form` while keeping legacy `body` compatibility.
- Render `body_form` as JMeter HTTP arguments with `HTTPSampler.postBodyRaw=false`.
- Add a default `Content-Type: application/x-www-form-urlencoded` header for form bodies when no content type is already set.
- Import OpenAPI, Postman, and HAR request bodies into the explicit body shapes where possible.
- Add a runnable form-urlencoded example and update docs, limitations, and testing notes.

## Tests

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go build -o bin/loadwright ./cmd/loadwright`
- Compiled all runnable YAML examples.
- Validated and compiled `examples/api/form-urlencoded.yaml`, then inspected the generated JMX for form arguments.