### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+No unreleased changes.
+
+## 0.2.0 - 2026-05-24
+
 - Remove the legacy Python prototype from the public repository.
 - Add public project-status badges and initial prototype attribution.
 - Add mailmap attribution for Jaykumar Gori's earlier commit identities.

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,8 +37,8 @@ bin/loadwright report results/release-smoke/results.jtl --out-dir results/releas
 ## Tagging
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 Pushing the tag triggers `.github/workflows/release.yml`, which publishes GitHub release artifacts and GHCR images.


### PR DESCRIPTION
## Summary
- move changelog entries into the v0.2.0 release section
- make release checklist tag commands version-agnostic

## Validation
- go test ./...
- go vet ./...
- actionlint
- goreleaser check
- goreleaser release --snapshot --clean --skip=publish
- go build -o bin/loadwright ./cmd/loadwright
- bin/loadwright version
- bin/loadwright validate examples/api/basic.yaml
- bin/loadwright compile examples/api/basic.yaml -o /tmp/loadwright-basic.jmx
- bin/loadwright doctor --deep
- bin/loadwright run examples/api/query-params.yaml --out-dir results/release-smoke --ci
- bin/loadwright report results/release-smoke/results.jtl --out-dir results/release-smoke --error-rate-lt 1 --p95-ms-lt 3000 --ci

Note: the v0.2.0 tag has already been pushed and the release workflow was triggered from this commit.