### PR TITLE
feat(import): add multipart form-data support

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,6 +34,14 @@ bin/loadwright run examples/api/form-urlencoded.yaml --ci
 
 Demonstrates `application/x-www-form-urlencoded` request bodies with `body_form`.
 
+## Multipart Upload
+
+```bash
+bin/loadwright run examples/api/multipart-upload.yaml --ci
+```
+
+Demonstrates multipart form-data uploads with `body_multipart`.
+
 ## Checkout Flow
 
 ```bash

--- a/docs/har-import.md
+++ b/docs/har-import.md
@@ -19,8 +19,9 @@ bin/loadwright import har capture.har --base-url https://staging.example.com -o 
 - The HAR filename becomes the spec name.
 - The first request origin becomes `target` unless `--base-url` is provided.
 - Supported requests become Loadwright HTTP requests.
-- Method, path, query params, headers, and JSON/text request bodies are imported.
+- Method, path, query params, headers, JSON/text request bodies, and multipart form-data params are imported.
 - Form params are imported as runnable `body_form` specs.
+- Text multipart params are imported as runnable `body_multipart` specs.
 - Unsupported or lossy capture details are reported as warnings.
 
 ## Current Limitations
@@ -28,7 +29,7 @@ bin/loadwright import har capture.har --base-url https://staging.example.com -o 
 - HAR 1.2 JSON only.
 - Browser replay semantics are not reproduced.
 - Cookies are not imported.
-- File uploads and encoded/binary request bodies are skipped with warnings.
-- Multipart form-data is not rendered as multipart JMeter requests yet.
+- File uploads are skipped with warnings because HAR captures do not include runnable local file sources.
+- Encoded/binary request bodies are skipped with warnings.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,13 +1,13 @@
 # Limitations
 
-Loadwright `v0.1.0` is intentionally focused on HTTP and WebSocket API load-test workflows.
+Loadwright is intentionally focused on HTTP and WebSocket API load-test workflows.
 
 ## In Scope
 
 - YAML specs for HTTP API requests.
 - GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS requests.
 - Query params, headers, JSON/string bodies, expected HTTP status assertions.
-- Urlencoded form bodies.
+- Urlencoded and multipart form bodies.
 - Basic and bearer auth helpers.
 - Environment files and simple variable substitution.
 - CSV data sources.
@@ -25,7 +25,6 @@ Loadwright `v0.1.0` is intentionally focused on HTTP and WebSocket API load-test
 - Distributed load generation across multiple workers.
 - Historical trend storage.
 - Browser-level performance testing.
-- Multipart form-data request rendering.
 - AI-assisted spec generation or result explanation.
 
 ## Compatibility Boundary

--- a/docs/postman-import.md
+++ b/docs/postman-import.md
@@ -20,18 +20,18 @@ bin/loadwright import postman collection.json --base-url https://staging.example
 - Collection variables become Loadwright variables.
 - Folders are included in request names.
 - Supported requests become Loadwright HTTP requests.
-- Method, path, query params, headers, raw JSON/text bodies, urlencoded fields, and text form-data fields are imported.
+- Method, path, query params, headers, raw JSON/text bodies, urlencoded fields, and multipart form-data fields are imported.
 - Collection-level bearer/basic auth becomes global Loadwright auth.
 - Request-level bearer/basic auth becomes request auth.
 - Postman variables such as `{{base_url}}` remain reviewable in the YAML output.
 - Urlencoded fields become runnable `body_form` specs.
-- Text form-data fields are imported as flat starter bodies with warnings.
+- Multipart form-data fields become runnable `body_multipart` specs.
 
 ## Current Limitations
 
 - Postman Collection v2.1 JSON only.
 - Postman pre-request scripts and tests are not executed or translated.
-- File uploads, GraphQL, and advanced auth modes are reported as warnings and skipped where needed.
-- Multipart form-data is not rendered as multipart JMeter requests yet, so review generated form-data starter specs before CI use.
+- GraphQL and advanced auth modes are reported as warnings and skipped where needed.
+- Multiple file sources for a single form-data field are reduced to the first file with a warning.
 - Multiple target hosts are imported into a single Loadwright target; review warnings before using the generated spec in CI.
 - Imported specs are starter specs and should be reviewed before CI use.

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -75,6 +75,22 @@ requests:
 
 `body_form` compiles to JMeter HTTP arguments with `HTTPSampler.postBodyRaw=false` and adds `Content-Type: application/x-www-form-urlencoded` when no content type header is already set.
 
+Multipart form body:
+
+```yaml
+requests:
+  - method: POST
+    path: /upload
+    body_multipart:
+      - name: title
+        value: avatar
+      - name: avatar
+        file: ./avatar.png
+        content_type: image/png
+```
+
+`body_multipart` compiles to JMeter multipart form-data arguments and file arguments. Text parts use `value`; file parts use `file` plus optional `content_type`. Loadwright lets JMeter set the multipart `Content-Type` boundary.
+
 ## Variables
 
 Variables can be referenced with `{{name}}`.

--- a/examples/api/multipart-upload.yaml
+++ b/examples/api/multipart-upload.yaml
@@ -1,0 +1,21 @@
+name: multipart-upload-example
+target: https://httpbin.org
+load:
+  users: 2
+  ramp_up: 5s
+  loops: 2
+requests:
+  - name: upload csv
+    method: POST
+    path: /post
+    body_multipart:
+      - name: title
+        value: users
+      - name: users
+        file: users.csv
+        content_type: text/csv
+    expect:
+      status: 200
+thresholds:
+  error_rate_lt: 1
+  p95_ms_lt: 3000

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -213,6 +213,10 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		thresholds = loaded.Thresholds
+		if err := stageMultipartFiles(loaded, filepath.Dir(input), outputDir); err != nil {
+			fmt.Fprintf(stderr, "stage multipart files failed: %v\n", err)
+			return 1
+		}
 		jmxPath = filepath.Join(outputDir, jmx.SafeName(loaded.Name)+".jmx")
 		if err := jmx.Compile(loaded, jmxPath); err != nil {
 			fmt.Fprintf(stderr, "compile failed: %v\n", err)
@@ -534,6 +538,53 @@ func loadResolvedSpec(path string, envFile string) (*spec.Spec, error) {
 		return nil, err
 	}
 	return loaded.Resolve(env, spec.WithBaseDir(filepath.Dir(path)))
+}
+
+func stageMultipartFiles(loaded *spec.Spec, specDir string, outputDir string) error {
+	next := 1
+	for requestIndex := range loaded.Requests {
+		for partIndex := range loaded.Requests[requestIndex].BodyMultipart {
+			part := &loaded.Requests[requestIndex].BodyMultipart[partIndex]
+			if part.File == "" || strings.Contains(part.File, "${") {
+				continue
+			}
+			source := part.File
+			if !filepath.IsAbs(source) {
+				source = filepath.Join(specDir, source)
+			}
+			sourceFile, err := os.Open(source)
+			if err != nil {
+				return fmt.Errorf("requests[%d].body_multipart[%d].file: %w", requestIndex, partIndex, err)
+			}
+			stageDir := filepath.Join(outputDir, "files")
+			if err := os.MkdirAll(stageDir, 0o755); err != nil {
+				_ = sourceFile.Close()
+				return err
+			}
+			name := fmt.Sprintf("%03d-%s", next, filepath.Base(source))
+			next++
+			target := filepath.Join(stageDir, name)
+			targetFile, err := os.Create(target)
+			if err != nil {
+				_ = sourceFile.Close()
+				return err
+			}
+			_, copyErr := io.Copy(targetFile, sourceFile)
+			closeTargetErr := targetFile.Close()
+			closeSourceErr := sourceFile.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeTargetErr != nil {
+				return closeTargetErr
+			}
+			if closeSourceErr != nil {
+				return closeSourceErr
+			}
+			part.File = filepath.ToSlash(filepath.Join("files", name))
+		}
+	}
+	return nil
 }
 
 func writeSpecError(w io.Writer, err error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -408,14 +408,15 @@ func TestRunImportPostmanCreatesSpecAndWarnings(t *testing.T) {
 	if !strings.Contains(string(data), "target: '{{base_url}}'") ||
 		!strings.Contains(string(data), "name: Create user") ||
 		!strings.Contains(string(data), "name: Ada") ||
-		!strings.Contains(string(data), "title: avatar") ||
+		!strings.Contains(string(data), "body_multipart:") ||
+		!strings.Contains(string(data), "value: avatar") ||
+		!strings.Contains(string(data), "file: /tmp/avatar.png") ||
 		!strings.Contains(string(data), "body_form:") ||
 		!strings.Contains(string(data), "username: demo") {
 		t.Fatalf("unexpected imported spec: %s", data)
 	}
-	if !strings.Contains(stderr.String(), `warning: Upload: form-data file field "avatar" was skipped`) ||
-		!strings.Contains(stderr.String(), "warning: Upload: form-data fields imported as a flat object starter body; review multipart encoding before CI use") {
-		t.Fatalf("expected warning, got stderr=%s", stderr.String())
+	if stderr.String() != "" {
+		t.Fatalf("unexpected warning, got stderr=%s", stderr.String())
 	}
 }
 
@@ -676,6 +677,53 @@ thresholds:
 	}
 	if manifest.StartedAt == "" || manifest.FinishedAt == "" {
 		t.Fatalf("expected timestamps: %+v", manifest)
+	}
+}
+
+func TestRunSpecStagesMultipartFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	if err := os.MkdirAll("specs/fixtures", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("specs/fixtures/avatar.txt", []byte("avatar"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	specYAML := `name: multipart-run
+target: https://example.com
+requests:
+  - name: upload
+    method: POST
+    path: /upload
+    body_multipart:
+      - name: title
+        value: avatar
+      - name: avatar
+        file: fixtures/avatar.txt
+        content_type: text/plain
+`
+	if err := os.WriteFile("specs/spec.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "specs/spec.yaml", "--out-dir", "results/multipart"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stagedPath := filepath.Join("results", "multipart", "files", "001-avatar.txt")
+	if data, err := os.ReadFile(stagedPath); err != nil || string(data) != "avatar" {
+		t.Fatalf("staged file = %q, %v", data, err)
+	}
+	jmxData, err := os.ReadFile(filepath.Join("results", "multipart", "multipart-run.jmx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(jmxData), `<stringProp name="File.path">files/001-avatar.txt</stringProp>`) {
+		t.Fatalf("JMX did not reference staged multipart file: %s", jmxData)
 	}
 }
 

--- a/internal/har/importer.go
+++ b/internal/har/importer.go
@@ -166,16 +166,17 @@ func requestFromHAR(index int, harRequest Request) (spec.Request, string, []stri
 	warnings = append(warnings, bodyWarnings...)
 
 	return spec.Request{
-		Name:     name,
-		Method:   method,
-		Path:     requestPath,
-		Headers:  headers,
-		Query:    query,
-		Body:     body.Legacy,
-		BodyJSON: body.JSON,
-		BodyText: body.Text,
-		BodyForm: body.Form,
-		Expect:   spec.Expect{Status: 200},
+		Name:          name,
+		Method:        method,
+		Path:          requestPath,
+		Headers:       headers,
+		Query:         query,
+		Body:          body.Legacy,
+		BodyJSON:      body.JSON,
+		BodyText:      body.Text,
+		BodyForm:      body.Form,
+		BodyMultipart: body.Multipart,
+		Expect:        spec.Expect{Status: 200},
 	}, target, warnings, true
 }
 
@@ -227,10 +228,11 @@ func headersFromHAR(requestName string, headers []NameValue) (map[string]string,
 }
 
 type requestBody struct {
-	Legacy any
-	JSON   any
-	Text   string
-	Form   map[string]string
+	Legacy    any
+	JSON      any
+	Text      string
+	Form      map[string]string
+	Multipart []spec.MultipartPart
 }
 
 func bodyFromHAR(requestName string, postData *PostData, headers map[string]string) (requestBody, []string) {
@@ -241,10 +243,12 @@ func bodyFromHAR(requestName string, postData *PostData, headers map[string]stri
 		return requestBody{}, []string{fmt.Sprintf("%s request body uses %s encoding and was skipped", requestName, postData.Encoding)}
 	}
 	if len(postData.Params) > 0 {
-		for _, param := range postData.Params {
-			if strings.TrimSpace(param.FileName) != "" {
-				return requestBody{}, []string{fmt.Sprintf("%s has file upload form data; body was skipped", requestName)}
+		if isMultipartMime(postData.MimeType) || hasFileParam(postData.Params) {
+			parts, warnings := multipartParamsBody(requestName, postData.Params)
+			if len(parts) == 0 {
+				return requestBody{}, warnings
 			}
+			return requestBody{Multipart: parts}, warnings
 		}
 		return requestBody{Form: paramsBody(postData.Params)}, nil
 	}
@@ -263,6 +267,37 @@ func bodyFromHAR(requestName string, postData *PostData, headers map[string]stri
 		return requestBody{Text: text}, []string{fmt.Sprintf("%s body looked like JSON but could not be parsed; imported as string", requestName)}
 	}
 	return requestBody{Text: text}, nil
+}
+
+func multipartParamsBody(requestName string, params []PostParam) ([]spec.MultipartPart, []string) {
+	out := make([]spec.MultipartPart, 0, len(params))
+	var warnings []string
+	for _, param := range params {
+		name := strings.TrimSpace(param.Name)
+		if name == "" {
+			continue
+		}
+		if fileName := strings.TrimSpace(param.FileName); fileName != "" {
+			warnings = append(warnings, fmt.Sprintf("%s form-data file field %q was skipped because HAR does not include a runnable local file source", requestName, name))
+			continue
+		}
+		value := stringify(param.Value)
+		out = append(out, spec.MultipartPart{Name: name, Value: &value})
+	}
+	return out, warnings
+}
+
+func hasFileParam(params []PostParam) bool {
+	for _, param := range params {
+		if strings.TrimSpace(param.FileName) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMultipartMime(value string) bool {
+	return strings.Contains(strings.ToLower(value), "multipart/form-data")
 }
 
 func paramsBody(params []PostParam) map[string]string {

--- a/internal/har/importer_test.go
+++ b/internal/har/importer_test.go
@@ -112,6 +112,34 @@ func TestImportFormParamsAsFormBody(t *testing.T) {
 	}
 }
 
+func TestImportMultipartParamsAsMultipartBody(t *testing.T) {
+	result, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
+		Method: "POST",
+		URL:    "https://api.example.com/upload",
+		PostData: &PostData{
+			MimeType: "multipart/form-data; boundary=----loadwright",
+			Params: []PostParam{
+				{Name: "title", Value: "avatar"},
+				{Name: "avatar", FileName: "fixtures/avatar.png", ContentType: "image/png"},
+			},
+		},
+	}}}}}, Options{Name: "Multipart"})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+	parts := result.Spec.Requests[0].BodyMultipart
+	if len(parts) != 1 ||
+		parts[0].Name != "title" ||
+		parts[0].Value == nil ||
+		*parts[0].Value != "avatar" {
+		t.Fatalf("body_multipart = %+v", parts)
+	}
+	if len(result.Warnings) != 1 ||
+		!strings.Contains(result.Warnings[0], `POST /upload form-data file field "avatar" was skipped`) {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+}
+
 func TestImportRejectsNoSupportedRequests(t *testing.T) {
 	_, err := Import(Archive{Log: Log{Entries: []Entry{{Request: Request{
 		Method: "TRACE",

--- a/internal/jmx/generator.go
+++ b/internal/jmx/generator.go
@@ -118,6 +118,7 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 	target, _ := url.Parse(s.Target)
 	fmt.Fprintf(b, `        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="%s" enabled="true">`+"\n", esc(r.Name))
 	body := rawBodyString(r)
+	multipart := len(r.BodyMultipart) > 0
 	if body != "" {
 		b.WriteString("          <boolProp name=\"HTTPSampler.postBodyRaw\">true</boolProp>\n")
 	} else {
@@ -131,6 +132,8 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 		fmt.Fprintf(b, "                <stringProp name=\"Argument.value\">%s</stringProp>\n", esc(body))
 		b.WriteString("                <stringProp name=\"Argument.metadata\">=</stringProp>\n")
 		b.WriteString("              </elementProp>\n")
+	} else if multipart {
+		writeMultipartTextArguments(b, r.BodyMultipart)
 	} else if len(r.BodyForm) > 0 {
 		writeFormArguments(b, r.BodyForm)
 	} else {
@@ -138,6 +141,9 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 	}
 	b.WriteString("            </collectionProp>\n")
 	b.WriteString("          </elementProp>\n")
+	if multipart {
+		writeMultipartFileArguments(b, r.BodyMultipart)
+	}
 	fmt.Fprintf(b, "          <stringProp name=\"HTTPSampler.domain\">%s</stringProp>\n", esc(target.Hostname()))
 	fmt.Fprintf(b, "          <stringProp name=\"HTTPSampler.port\">%s</stringProp>\n", esc(target.Port()))
 	fmt.Fprintf(b, "          <stringProp name=\"HTTPSampler.protocol\">%s</stringProp>\n", esc(target.Scheme))
@@ -147,7 +153,7 @@ func writeHTTPSampler(b *strings.Builder, s *spec.Spec, r spec.Request) {
 	b.WriteString("          <boolProp name=\"HTTPSampler.follow_redirects\">true</boolProp>\n")
 	b.WriteString("          <boolProp name=\"HTTPSampler.auto_redirects\">false</boolProp>\n")
 	b.WriteString("          <boolProp name=\"HTTPSampler.use_keepalive\">true</boolProp>\n")
-	b.WriteString("          <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">false</boolProp>\n")
+	fmt.Fprintf(b, "          <boolProp name=\"HTTPSampler.DO_MULTIPART_POST\">%s</boolProp>\n", boolLiteral(multipart))
 	b.WriteString("          <stringProp name=\"HTTPSampler.embedded_url_re\"></stringProp>\n")
 	timeoutMS := ""
 	if r.Timeout.Set {
@@ -412,6 +418,38 @@ func writeFormArguments(b *strings.Builder, fields map[string]string) {
 	}
 }
 
+func writeMultipartTextArguments(b *strings.Builder, parts []spec.MultipartPart) {
+	for _, part := range parts {
+		if part.Value == nil {
+			continue
+		}
+		fmt.Fprintf(b, "              <elementProp name=\"%s\" elementType=\"HTTPArgument\">\n", esc(part.Name))
+		b.WriteString("                <boolProp name=\"HTTPArgument.always_encode\">false</boolProp>\n")
+		fmt.Fprintf(b, "                <stringProp name=\"Argument.name\">%s</stringProp>\n", esc(part.Name))
+		fmt.Fprintf(b, "                <stringProp name=\"Argument.value\">%s</stringProp>\n", esc(*part.Value))
+		b.WriteString("                <stringProp name=\"Argument.metadata\">=</stringProp>\n")
+		b.WriteString("                <boolProp name=\"HTTPArgument.use_equals\">true</boolProp>\n")
+		b.WriteString("              </elementProp>\n")
+	}
+}
+
+func writeMultipartFileArguments(b *strings.Builder, parts []spec.MultipartPart) {
+	b.WriteString("          <elementProp name=\"HTTPsampler.Files\" elementType=\"HTTPFileArgs\">\n")
+	b.WriteString("            <collectionProp name=\"HTTPFileArgs.files\">\n")
+	for _, part := range parts {
+		if part.File == "" {
+			continue
+		}
+		fmt.Fprintf(b, "              <elementProp name=\"%s\" elementType=\"HTTPFileArg\">\n", esc(part.Name))
+		fmt.Fprintf(b, "                <stringProp name=\"File.path\">%s</stringProp>\n", esc(part.File))
+		fmt.Fprintf(b, "                <stringProp name=\"File.paramname\">%s</stringProp>\n", esc(part.Name))
+		fmt.Fprintf(b, "                <stringProp name=\"File.mimetype\">%s</stringProp>\n", esc(part.ContentType))
+		b.WriteString("              </elementProp>\n")
+	}
+	b.WriteString("            </collectionProp>\n")
+	b.WriteString("          </elementProp>\n")
+}
+
 func writeHeaders(b *strings.Builder, headers map[string]string) {
 	b.WriteString("          <HeaderManager guiclass=\"HeaderPanel\" testclass=\"HeaderManager\" testname=\"HTTP Headers\" enabled=\"true\">\n")
 	b.WriteString("            <collectionProp name=\"HeaderManager.headers\">\n")
@@ -489,6 +527,16 @@ func jsonable(value any) any {
 }
 
 func requestHeaders(r spec.Request) map[string]string {
+	if len(r.BodyMultipart) > 0 {
+		headers := map[string]string{}
+		for key, value := range r.Headers {
+			if strings.EqualFold(key, "content-type") {
+				continue
+			}
+			headers[key] = value
+		}
+		return headers
+	}
 	if len(r.BodyForm) == 0 || hasHeader(r.Headers, "content-type") {
 		return r.Headers
 	}
@@ -498,6 +546,13 @@ func requestHeaders(r spec.Request) map[string]string {
 	}
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 	return headers
+}
+
+func boolLiteral(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }
 
 func hasHeader(headers map[string]string, name string) bool {

--- a/internal/jmx/generator_test.go
+++ b/internal/jmx/generator_test.go
@@ -160,6 +160,45 @@ func TestRenderFormBodyArguments(t *testing.T) {
 	}
 }
 
+func TestRenderMultipartBodyArguments(t *testing.T) {
+	loops := 1
+	title := "avatar"
+	loaded := &spec.Spec{
+		Name:   "multipart body",
+		Target: "https://api.example.com",
+		Load:   spec.Load{Users: 1, RampUp: spec.Duration{Seconds: 1, Set: true}, Loops: &loops},
+		Requests: []spec.Request{{
+			Name:    "upload",
+			Method:  "POST",
+			Path:    "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data", "X-Trace": "yes"},
+			BodyMultipart: []spec.MultipartPart{
+				{Name: "title", Value: &title},
+				{Name: "avatar", File: "fixtures/avatar.png", ContentType: "image/png"},
+			},
+		}},
+	}
+	rendered := Render(loaded)
+	for _, expected := range []string{
+		`<boolProp name="HTTPSampler.postBodyRaw">false</boolProp>`,
+		`<boolProp name="HTTPSampler.DO_MULTIPART_POST">true</boolProp>`,
+		`<elementProp name="title" elementType="HTTPArgument">`,
+		`<stringProp name="Argument.value">avatar</stringProp>`,
+		`<elementProp name="HTTPsampler.Files" elementType="HTTPFileArgs">`,
+		`<stringProp name="File.path">fixtures/avatar.png</stringProp>`,
+		`<stringProp name="File.paramname">avatar</stringProp>`,
+		`<stringProp name="File.mimetype">image/png</stringProp>`,
+		`<stringProp name="Header.name">X-Trace</stringProp>`,
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("multipart JMX missing %q\n%s", expected, rendered)
+		}
+	}
+	if strings.Contains(rendered, `<stringProp name="Header.name">Content-Type</stringProp>`) {
+		t.Fatalf("multipart JMX should let JMeter set Content-Type boundary\n%s", rendered)
+	}
+}
+
 func TestRenderDurationBasedLoad(t *testing.T) {
 	loaded := &spec.Spec{
 		Name:   "duration load",

--- a/internal/postman/importer.go
+++ b/internal/postman/importer.go
@@ -149,11 +149,12 @@ type RawBodyOptions struct {
 }
 
 type FormParam struct {
-	Key      string `json:"key"`
-	Value    any    `json:"value"`
-	Type     string `json:"type"`
-	Disabled bool   `json:"disabled"`
-	Src      any    `json:"src"`
+	Key         string `json:"key"`
+	Value       any    `json:"value"`
+	Type        string `json:"type"`
+	Disabled    bool   `json:"disabled"`
+	Src         any    `json:"src"`
+	ContentType string `json:"contentType"`
 }
 
 type Auth struct {
@@ -297,17 +298,18 @@ func requestFromPostman(item Item, folders []string, collectionAuth *Auth) (spec
 	}
 
 	return spec.Request{
-		Name:     requestName,
-		Method:   method,
-		Path:     requestPath,
-		Headers:  headers,
-		Query:    query,
-		Body:     body.Legacy,
-		BodyJSON: body.JSON,
-		BodyText: body.Text,
-		BodyForm: body.Form,
-		Auth:     requestAuth,
-		Expect:   spec.Expect{Status: 200},
+		Name:          requestName,
+		Method:        method,
+		Path:          requestPath,
+		Headers:       headers,
+		Query:         query,
+		Body:          body.Legacy,
+		BodyJSON:      body.JSON,
+		BodyText:      body.Text,
+		BodyForm:      body.Form,
+		BodyMultipart: body.Multipart,
+		Auth:          requestAuth,
+		Expect:        spec.Expect{Status: 200},
 	}, target, warnings, true
 }
 
@@ -442,10 +444,11 @@ func headersFromPostman(headers []Header) map[string]string {
 }
 
 type requestBody struct {
-	Legacy any
-	JSON   any
-	Text   string
-	Form   map[string]string
+	Legacy    any
+	JSON      any
+	Text      string
+	Form      map[string]string
+	Multipart []spec.MultipartPart
 }
 
 func bodyFromPostman(body Body, headers map[string]string) (requestBody, []string) {
@@ -476,12 +479,11 @@ func bodyFromPostman(body Body, headers map[string]string) (requestBody, []strin
 		}
 		return requestBody{Form: form}, nil
 	case "formdata":
-		form, warnings := formDataBody(body.FormData)
-		if len(form) == 0 {
+		parts, warnings := formDataBody(body.FormData)
+		if len(parts) == 0 {
 			return requestBody{}, warnings
 		}
-		warnings = append(warnings, "form-data fields imported as a flat object starter body; review multipart encoding before CI use")
-		return requestBody{Legacy: form}, warnings
+		return requestBody{Multipart: parts}, warnings
 	default:
 		return requestBody{}, []string{fmt.Sprintf("request body mode %q is not imported yet", mode)}
 	}
@@ -499,8 +501,8 @@ func formParamsBody(params []FormParam) map[string]string {
 	return out
 }
 
-func formDataBody(params []FormParam) (map[string]any, []string) {
-	out := map[string]any{}
+func formDataBody(params []FormParam) ([]spec.MultipartPart, []string) {
+	var out []spec.MultipartPart
 	var warnings []string
 	for _, param := range params {
 		key := strings.TrimSpace(param.Key)
@@ -508,10 +510,23 @@ func formDataBody(params []FormParam) (map[string]any, []string) {
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(param.Type), "file") || hasFormFileSource(param.Src) {
-			warnings = append(warnings, fmt.Sprintf("form-data file field %q was skipped", key))
+			source, multiple := firstFormFileSource(param.Src)
+			if source == "" {
+				warnings = append(warnings, fmt.Sprintf("form-data file field %q has no file source and was skipped", key))
+				continue
+			}
+			if multiple {
+				warnings = append(warnings, fmt.Sprintf("form-data file field %q has multiple file sources; imported the first one", key))
+			}
+			out = append(out, spec.MultipartPart{
+				Name:        key,
+				File:        source,
+				ContentType: strings.TrimSpace(param.ContentType),
+			})
 			continue
 		}
-		out[key] = stringify(param.Value)
+		value := stringify(param.Value)
+		out = append(out, spec.MultipartPart{Name: key, Value: &value})
 	}
 	return out, warnings
 }
@@ -527,6 +542,36 @@ func hasFormFileSource(value any) bool {
 	default:
 		return true
 	}
+}
+
+func firstFormFileSource(value any) (string, bool) {
+	var sources []string
+	switch typed := value.(type) {
+	case nil:
+		return "", false
+	case string:
+		return strings.TrimSpace(typed), false
+	case []any:
+		for _, item := range typed {
+			source := strings.TrimSpace(stringify(item))
+			if source != "" {
+				sources = append(sources, source)
+			}
+		}
+	case []string:
+		for _, item := range typed {
+			source := strings.TrimSpace(item)
+			if source != "" {
+				sources = append(sources, source)
+			}
+		}
+	default:
+		return strings.TrimSpace(stringify(typed)), false
+	}
+	if len(sources) == 0 {
+		return "", false
+	}
+	return sources[0], len(sources) > 1
 }
 
 func shouldParseJSON(raw string, body Body, headers map[string]string) bool {

--- a/internal/postman/importer_test.go
+++ b/internal/postman/importer_test.go
@@ -142,7 +142,7 @@ func TestImportURLEncodedBodyAsFormBody(t *testing.T) {
 	}
 }
 
-func TestImportFormDataBodySkipsFileFields(t *testing.T) {
+func TestImportFormDataBodyAsMultipart(t *testing.T) {
 	result, err := Import(Collection{
 		Info: Info{Name: "Multipart"},
 		Items: []Item{{
@@ -155,7 +155,7 @@ func TestImportFormDataBodySkipsFileFields(t *testing.T) {
 					Mode: "formdata",
 					FormData: []FormParam{
 						{Key: "title", Value: "avatar"},
-						{Key: "avatar", Type: "file", Src: "/tmp/avatar.png"},
+						{Key: "avatar", Type: "file", Src: "/tmp/avatar.png", ContentType: "image/png"},
 					},
 				},
 			},
@@ -164,21 +164,18 @@ func TestImportFormDataBodySkipsFileFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Import() error = %v", err)
 	}
-	body := result.Spec.Requests[0].Body.(map[string]any)
-	if body["title"] != "avatar" {
-		t.Fatalf("body = %+v", body)
+	parts := result.Spec.Requests[0].BodyMultipart
+	if len(parts) != 2 ||
+		parts[0].Name != "title" ||
+		parts[0].Value == nil ||
+		*parts[0].Value != "avatar" ||
+		parts[1].Name != "avatar" ||
+		parts[1].File != "/tmp/avatar.png" ||
+		parts[1].ContentType != "image/png" {
+		t.Fatalf("body_multipart = %+v", parts)
 	}
-	if _, exists := body["avatar"]; exists {
-		t.Fatalf("file field imported: %+v", body)
-	}
-	joined := strings.Join(result.Warnings, "\n")
-	for _, expected := range []string{
-		`Upload: form-data file field "avatar" was skipped`,
-		"Upload: form-data fields imported as a flat object starter body; review multipart encoding before CI use",
-	} {
-		if !strings.Contains(joined, expected) {
-			t.Fatalf("missing warning %q in %+v", expected, result.Warnings)
-		}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %+v", result.Warnings)
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -128,20 +128,28 @@ type DataSet struct {
 }
 
 type Request struct {
-	Name      string            `yaml:"name"`
-	Protocol  string            `yaml:"protocol,omitempty"`
-	Method    string            `yaml:"method"`
-	Path      string            `yaml:"path"`
-	Headers   map[string]string `yaml:"headers,omitempty"`
-	Query     map[string]string `yaml:"query,omitempty"`
-	Body      any               `yaml:"body,omitempty"`
-	BodyJSON  any               `yaml:"body_json,omitempty"`
-	BodyText  string            `yaml:"body_text,omitempty"`
-	BodyForm  map[string]string `yaml:"body_form,omitempty"`
-	Auth      Auth              `yaml:"auth,omitempty"`
-	Timeout   Duration          `yaml:"timeout,omitempty"`
-	Expect    Expect            `yaml:"expect"`
-	WebSocket WebSocket         `yaml:"websocket,omitempty"`
+	Name          string            `yaml:"name"`
+	Protocol      string            `yaml:"protocol,omitempty"`
+	Method        string            `yaml:"method"`
+	Path          string            `yaml:"path"`
+	Headers       map[string]string `yaml:"headers,omitempty"`
+	Query         map[string]string `yaml:"query,omitempty"`
+	Body          any               `yaml:"body,omitempty"`
+	BodyJSON      any               `yaml:"body_json,omitempty"`
+	BodyText      string            `yaml:"body_text,omitempty"`
+	BodyForm      map[string]string `yaml:"body_form,omitempty"`
+	BodyMultipart []MultipartPart   `yaml:"body_multipart,omitempty"`
+	Auth          Auth              `yaml:"auth,omitempty"`
+	Timeout       Duration          `yaml:"timeout,omitempty"`
+	Expect        Expect            `yaml:"expect"`
+	WebSocket     WebSocket         `yaml:"websocket,omitempty"`
+}
+
+type MultipartPart struct {
+	Name        string  `yaml:"name"`
+	Value       *string `yaml:"value,omitempty"`
+	File        string  `yaml:"file,omitempty"`
+	ContentType string  `yaml:"content_type,omitempty"`
 }
 
 type Auth struct {
@@ -354,7 +362,7 @@ func (r *Request) normalizeAndValidateWebSocket(index int) error {
 	if !r.Auth.IsZero() {
 		return fmt.Errorf("requests[%d].auth is not supported for websocket requests", index)
 	}
-	hasHTTPOnlyBody := r.Body != nil || r.BodyJSON != nil || strings.TrimSpace(r.BodyText) != "" || len(r.BodyForm) > 0
+	hasHTTPOnlyBody := r.Body != nil || r.BodyJSON != nil || strings.TrimSpace(r.BodyText) != "" || len(r.BodyForm) > 0 || len(r.BodyMultipart) > 0
 	if len(r.Headers) > 0 || len(r.Query) > 0 || hasHTTPOnlyBody || r.Expect.Status > 0 {
 		return fmt.Errorf("requests[%d] websocket requests only support websocket.* fields plus optional path and timeout", index)
 	}
@@ -442,6 +450,27 @@ func (r *Request) validateBodyFields(index int) error {
 		for key := range r.BodyForm {
 			if strings.TrimSpace(key) == "" {
 				return fmt.Errorf("requests[%d].body_form contains an empty field name", index)
+			}
+		}
+	}
+	if len(r.BodyMultipart) > 0 {
+		fields = append(fields, "body_multipart")
+		for partIndex := range r.BodyMultipart {
+			part := &r.BodyMultipart[partIndex]
+			part.Name = strings.TrimSpace(part.Name)
+			part.File = strings.TrimSpace(part.File)
+			part.ContentType = strings.TrimSpace(part.ContentType)
+			if part.Name == "" {
+				return fmt.Errorf("requests[%d].body_multipart[%d].name is required", index, partIndex)
+			}
+			if part.Value == nil && part.File == "" {
+				return fmt.Errorf("requests[%d].body_multipart[%d] must set value or file", index, partIndex)
+			}
+			if part.Value != nil && part.File != "" {
+				return fmt.Errorf("requests[%d].body_multipart[%d] must set only one of value or file", index, partIndex)
+			}
+			if part.Value != nil && part.ContentType != "" {
+				return fmt.Errorf("requests[%d].body_multipart[%d].content_type is only supported for file parts", index, partIndex)
 			}
 		}
 	}
@@ -603,6 +632,10 @@ func renderRequest(request Request, vars map[string]string, index int) (Request,
 	if err != nil {
 		return Request{}, fmt.Errorf("requests[%d].body_form: %w", index, err)
 	}
+	out.BodyMultipart, err = renderMultipartParts(request.BodyMultipart, vars)
+	if err != nil {
+		return Request{}, fmt.Errorf("requests[%d].body_multipart: %w", index, err)
+	}
 	out.Auth, err = renderAuth(request.Auth, vars, fmt.Sprintf("requests[%d].auth", index))
 	if err != nil {
 		return Request{}, err
@@ -610,6 +643,35 @@ func renderRequest(request Request, vars map[string]string, index int) (Request,
 	out.WebSocket, err = renderWebSocket(request.WebSocket, vars, index)
 	if err != nil {
 		return Request{}, err
+	}
+	return out, nil
+}
+
+func renderMultipartParts(parts []MultipartPart, vars map[string]string) ([]MultipartPart, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	out := make([]MultipartPart, len(parts))
+	for index, part := range parts {
+		rendered := part
+		var err error
+		if rendered.Name, err = renderString(part.Name, vars); err != nil {
+			return nil, fmt.Errorf("[%d].name: %w", index, err)
+		}
+		if part.Value != nil {
+			value, err := renderString(*part.Value, vars)
+			if err != nil {
+				return nil, fmt.Errorf("[%d].value: %w", index, err)
+			}
+			rendered.Value = &value
+		}
+		if rendered.File, err = renderString(part.File, vars); err != nil {
+			return nil, fmt.Errorf("[%d].file: %w", index, err)
+		}
+		if rendered.ContentType, err = renderString(part.ContentType, vars); err != nil {
+			return nil, fmt.Errorf("[%d].content_type: %w", index, err)
+		}
+		out[index] = rendered
 	}
 	return out, nil
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -316,6 +316,14 @@ requests:
     body_form:
       username: demo
       password: secret
+  - method: POST
+    path: /upload
+    body_multipart:
+      - name: title
+        value: avatar
+      - name: avatar
+        file: ./avatar.png
+        content_type: image/png
 `
 	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
@@ -333,6 +341,13 @@ requests:
 	if loaded.Requests[2].BodyForm["username"] != "demo" || loaded.Requests[2].BodyForm["password"] != "secret" {
 		t.Fatalf("body_form = %+v", loaded.Requests[2].BodyForm)
 	}
+	if len(loaded.Requests[3].BodyMultipart) != 2 ||
+		loaded.Requests[3].BodyMultipart[0].Value == nil ||
+		*loaded.Requests[3].BodyMultipart[0].Value != "avatar" ||
+		loaded.Requests[3].BodyMultipart[1].File != "./avatar.png" ||
+		loaded.Requests[3].BodyMultipart[1].ContentType != "image/png" {
+		t.Fatalf("body_multipart = %+v", loaded.Requests[3].BodyMultipart)
+	}
 }
 
 func TestRequestRejectsMultipleBodyShapes(t *testing.T) {
@@ -344,6 +359,31 @@ func TestRequestRejectsMultipleBodyShapes(t *testing.T) {
 	}
 	err := raw.NormalizeAndValidate(0)
 	if err == nil || !strings.Contains(err.Error(), "must set only one body field") {
+		t.Fatalf("NormalizeAndValidate() error = %v", err)
+	}
+}
+
+func TestRequestValidatesMultipartBody(t *testing.T) {
+	value := "avatar"
+	raw := Request{
+		Method: "POST",
+		Path:   "/upload",
+		BodyMultipart: []MultipartPart{
+			{Name: "title", Value: &value},
+			{Name: "avatar", File: "avatar.png", ContentType: "image/png"},
+		},
+	}
+	if err := raw.NormalizeAndValidate(0); err != nil {
+		t.Fatalf("NormalizeAndValidate() error = %v", err)
+	}
+
+	invalid := Request{
+		Method:        "POST",
+		Path:          "/upload",
+		BodyMultipart: []MultipartPart{{Name: "avatar"}},
+	}
+	err := invalid.NormalizeAndValidate(0)
+	if err == nil || !strings.Contains(err.Error(), "must set value or file") {
 		t.Fatalf("NormalizeAndValidate() error = %v", err)
 	}
 }
@@ -387,18 +427,25 @@ func TestResolvePreservesJMeterRuntimeVariables(t *testing.T) {
 		Name:   "csv",
 		Target: "https://example.com",
 		Requests: []Request{{
-			Path:     "/login",
-			BodyForm: map[string]string{"username": "${username}", "password": "{{password}}"},
+			Path: "/login",
+			BodyMultipart: []MultipartPart{
+				{Name: "username", Value: stringPtr("${username}")},
+				{Name: "password", Value: stringPtr("{{password}}")},
+				{Name: "avatar", File: "{{avatar_file}}", ContentType: "{{avatar_type}}"},
+			},
 		}},
-		Variables: map[string]string{"password": "secret"},
+		Variables: map[string]string{"password": "secret", "avatar_file": "avatar.png", "avatar_type": "image/png"},
 	}
 	resolved, err := raw.Resolve(nil)
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
-	bodyForm := resolved.Requests[0].BodyForm
-	if bodyForm["username"] != "${username}" || bodyForm["password"] != "secret" {
-		t.Fatalf("body_form not resolved correctly: %+v", bodyForm)
+	parts := resolved.Requests[0].BodyMultipart
+	if parts[0].Value == nil || *parts[0].Value != "${username}" ||
+		parts[1].Value == nil || *parts[1].Value != "secret" ||
+		parts[2].File != "avatar.png" ||
+		parts[2].ContentType != "image/png" {
+		t.Fatalf("body_multipart not resolved correctly: %+v", parts)
 	}
 }
 
@@ -739,5 +786,9 @@ func TestWebSocketDelayValidation(t *testing.T) {
 }
 
 func intPtr(value int) *int {
+	return &value
+}
+
+func stringPtr(value string) *string {
 	return &value
 }


### PR DESCRIPTION
## Summary
- add body_multipart spec support for text and file parts
- render multipart JMeter samplers with file args and JMeter-managed boundaries
- import Postman multipart form-data and preserve runnable file sources
- import HAR text multipart fields while warning for non-runnable HAR file uploads
- add docs and a multipart upload example

Closes #27

## Validation
- go test ./...
- go vet ./...
- git diff --check 3cf4c0d4097cffaab7f85a9941bd82da0b180a58
- bin/loadwright validate examples/api/multipart-upload.yaml
- bin/loadwright compile examples/api/multipart-upload.yaml -o /tmp/loadwright-review-multipart.jmx
- bin/loadwright run examples/api/multipart-upload.yaml --out-dir /tmp/loadwright-multipart-run --ci (4 samples, 0 errors)