### PR TITLE
Harden Docker/JMeter runtime diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ More docs:
 ## Commands
 
 ```bash
-loadwright doctor [--deep] [--image justb4/jmeter:5.6.3]
+loadwright doctor [--deep] [--image IMAGE]
 loadwright version
 loadwright init [path]
 loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
@@ -152,11 +152,11 @@ loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparis
 For WebSocket specs, build the bundled plugin image first, then pass it with `--image`:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.6.3
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
+bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.5
 ```
 
-The `docker/jmeter/Dockerfile` extends the pinned HTTP runtime image, `justb4/jmeter:5.6.3`, and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin.
+The `docker/jmeter/Dockerfile` extends the pinned HTTP runtime image, `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7`, and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ More docs:
 ## Commands
 
 ```bash
-loadwright doctor [--deep] [--image justb4/jmeter:latest]
+loadwright doctor [--deep] [--image justb4/jmeter:5.6.3]
 loadwright version
 loadwright init [path]
 loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
@@ -136,11 +136,11 @@ loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparis
 For WebSocket specs, build the bundled plugin image first, then pass it with `--image`:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:latest
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
+bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.6.3
 ```
 
-The `docker/jmeter/Dockerfile` extends `justb4/jmeter:latest` (the same base used for all HTTP runs) and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin.
+The `docker/jmeter/Dockerfile` extends the pinned HTTP runtime image, `justb4/jmeter:5.6.3`, and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin.
 
 ## Roadmap
 

--- a/docker/jmeter/Dockerfile
+++ b/docker/jmeter/Dockerfile
@@ -1,4 +1,4 @@
-FROM justb4/jmeter:latest
+FROM justb4/jmeter:5.6.3
 
 # Install the WebSocket Samplers plugin by Peter Doornbosch (v1.3.2)
 # https://github.com/ptrd/jmeter-websocket-samplers

--- a/docker/jmeter/Dockerfile
+++ b/docker/jmeter/Dockerfile
@@ -1,4 +1,4 @@
-FROM justb4/jmeter:5.6.3
+FROM justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
 
 # Install the WebSocket Samplers plugin by Peter Doornbosch (v1.3.2)
 # https://github.com/ptrd/jmeter-websocket-samplers

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,13 +32,6 @@ docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
 
 Use `loadwright doctor --deep --image <image:tag>` to verify that the configured image pulls and starts on your machine before running a load test.
 
-WebSocket specs require the bundled plugin-enabled image until plugin setup is automated:
-
-```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
-loadwright doctor --deep --image loadwright/jmeter-websocket:latest
-```
-
 ## Docker
 
 Docker is required for `loadwright run`, `loadwright doctor`, and `loadwright doctor --deep`. The basic doctor checks verify the Docker CLI, daemon reachability, writable directories, and image availability. The deep check also starts JMeter in the configured image.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,17 +16,25 @@ Release builds target:
 
 ## JMeter
 
-Generated plans target Apache JMeter 5.6.x-era JMX properties. The default runtime image is:
+Generated plans target Apache JMeter 5.6.x-era JMX properties. The default HTTP runtime image is pinned to the tested JMeter line:
 
 ```text
-justb4/jmeter:latest
+justb4/jmeter:5.6.3
 ```
 
-Use `loadwright doctor --deep` to verify that the configured image starts on your machine.
+Loadwright does not use floating `latest` tags as its support boundary. Patch releases may move to a newer pinned JMeter tag after the CLI, generated JMX, and report flow are tested against that image.
+
+HTTP specs use the default image unless `--image` is provided. WebSocket specs require a plugin-enabled image because the generated JMX uses the WebSocket Samplers plugin. Build the bundled image with:
+
+```sh
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
+```
+
+Use `loadwright doctor --deep --image <image:tag>` to verify that the configured image pulls and starts on your machine before running a load test.
 
 ## Docker
 
-Docker is required for `loadwright run` and `loadwright doctor --deep`.
+Docker is required for `loadwright run`, `loadwright doctor`, and `loadwright doctor --deep`. The basic doctor checks verify the Docker CLI, daemon reachability, writable directories, and image availability. The deep check also starts JMeter in the configured image.
 
 Docker is not required for:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,18 +16,18 @@ Release builds target:
 
 ## JMeter
 
-Generated plans target Apache JMeter 5.6.x-era JMX properties. The default HTTP runtime image is pinned to the tested JMeter line:
+Generated plans are tested against the pinned HTTP runtime image:
 
 ```text
-justb4/jmeter:5.6.3
+justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
 ```
 
-Loadwright does not use floating `latest` tags as its support boundary. Patch releases may move to a newer pinned JMeter tag after the CLI, generated JMX, and report flow are tested against that image.
+Loadwright does not use floating `latest` tags as its support boundary. Patch releases may move to a newer immutable image digest after the CLI, generated JMX, and report flow are tested against that image.
 
 HTTP specs use the default image unless `--image` is provided. WebSocket specs require a plugin-enabled image because the generated JMX uses the WebSocket Samplers plugin. Build the bundled image with:
 
 ```sh
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
 ```
 
 Use `loadwright doctor --deep --image <image:tag>` to verify that the configured image pulls and starts on your machine before running a load test.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -102,11 +102,11 @@ Demonstrates default and request-specific timeouts.
 
 ## WebSocket Echo
 
-WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter:5.6.3` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin), then reuse it for all WebSocket examples:
+WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin), then reuse it for all WebSocket examples:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.6.3
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
+bin/loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.5
 ```
 
 Demonstrates a WebSocket request that sends one message and checks the first response.
@@ -114,8 +114,8 @@ Demonstrates a WebSocket request that sends one message and checks the first res
 ## WebSocket Multi-Message
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.6.3
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .  # skip if already built
+bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.5
 ```
 
 Demonstrates a multi-message WebSocket sequence with delays and per-message assertions.
@@ -123,8 +123,8 @@ Demonstrates a multi-message WebSocket sequence with delays and per-message asse
 ## WebSocket Subprotocol
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-subprotocol.yaml --ci --image loadwright/jmeter-websocket:5.6.3
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .  # skip if already built
+bin/loadwright run examples/api/websocket-subprotocol.yaml --ci --image loadwright/jmeter-websocket:5.5
 ```
 
 Demonstrates WebSocket subprotocol negotiation and custom handshake headers.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -92,11 +92,11 @@ Demonstrates default and request-specific timeouts.
 
 ## WebSocket Echo
 
-WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter:latest` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin), then reuse it for all WebSocket examples:
+WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter:5.6.3` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin), then reuse it for all WebSocket examples:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:latest
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
+bin/loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.6.3
 ```
 
 Demonstrates a WebSocket request that sends one message and checks the first response.
@@ -104,8 +104,8 @@ Demonstrates a WebSocket request that sends one message and checks the first res
 ## WebSocket Multi-Message
 
 ```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:latest
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .  # skip if already built
+bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.6.3
 ```
 
 Demonstrates a multi-message WebSocket sequence with delays and per-message assertions.
@@ -113,8 +113,8 @@ Demonstrates a multi-message WebSocket sequence with delays and per-message asse
 ## WebSocket Subprotocol
 
 ```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-subprotocol.yaml --ci --image loadwright/jmeter-websocket:latest
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .  # skip if already built
+bin/loadwright run examples/api/websocket-subprotocol.yaml --ci --image loadwright/jmeter-websocket:5.6.3
 ```
 
 Demonstrates WebSocket subprotocol negotiation and custom handshake headers.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -26,7 +26,7 @@ bin/loadwright report results/manual-smoke/results.jtl --out-dir results/manual-
   "input_type": "yaml",
   "jmx": "results/20260425-120000/example-api.jmx",
   "generated_jmx": true,
-  "image": "justb4/jmeter:latest",
+  "image": "justb4/jmeter:5.6.3",
   "ci": true,
   "started_at": "2026-04-25T12:00:00Z",
   "finished_at": "2026-04-25T12:00:10Z",

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -26,7 +26,7 @@ bin/loadwright report results/manual-smoke/results.jtl --out-dir results/manual-
   "input_type": "yaml",
   "jmx": "results/20260425-120000/example-api.jmx",
   "generated_jmx": true,
-  "image": "justb4/jmeter:5.6.3",
+  "image": "justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7",
   "ci": true,
   "started_at": "2026-04-25T12:00:00Z",
   "finished_at": "2026-04-25T12:00:10Z",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,11 +18,11 @@ Start Docker Desktop or your Docker daemon, then rerun `loadwright doctor --deep
 
 ## Image Pull Or Startup Fails
 
-Loadwright uses `justb4/jmeter:5.6.3` by default for HTTP runs.
+Loadwright uses `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7` by default for HTTP runs.
 
 ```bash
-docker pull justb4/jmeter:5.6.3
-loadwright doctor --deep --image justb4/jmeter:5.6.3
+docker pull justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
+loadwright doctor --deep --image justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
 ```
 
 If your environment blocks public image pulls, mirror the image internally and pass it with `--image`:
@@ -59,9 +59,9 @@ If Docker reports `unauthorized`, use the release binary or `go install` path in
 WebSocket specs currently require the bundled plugin-enabled JMeter image.
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
-loadwright doctor --deep --image loadwright/jmeter-websocket:5.6.3
-loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.6.3
+docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
+loadwright doctor --deep --image loadwright/jmeter-websocket:5.5
+loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.5
 ```
 
 HTTP examples do not require this WebSocket image.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,11 +18,11 @@ Start Docker Desktop or your Docker daemon, then rerun `loadwright doctor --deep
 
 ## Image Pull Or Startup Fails
 
-Loadwright uses `justb4/jmeter:latest` by default for HTTP runs.
+Loadwright uses `justb4/jmeter:5.6.3` by default for HTTP runs.
 
 ```bash
-docker pull justb4/jmeter:latest
-loadwright doctor --deep --image justb4/jmeter:latest
+docker pull justb4/jmeter:5.6.3
+loadwright doctor --deep --image justb4/jmeter:5.6.3
 ```
 
 If your environment blocks public image pulls, mirror the image internally and pass it with `--image`:
@@ -59,9 +59,9 @@ If Docker reports `unauthorized`, use the release binary or `go install` path in
 WebSocket specs currently require the bundled plugin-enabled JMeter image.
 
 ```bash
-docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
-loadwright doctor --deep --image loadwright/jmeter-websocket:latest
-loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:latest
+docker build -t loadwright/jmeter-websocket:5.6.3 -f docker/jmeter/Dockerfile .
+loadwright doctor --deep --image loadwright/jmeter-websocket:5.6.3
+loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.6.3
 ```
 
 HTTP examples do not require this WebSocket image.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -59,7 +60,7 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, `Loadwright: Docker-first, spec-driven JMeter automation
 
 Usage:
-  loadwright doctor [--deep] [--image justb4/jmeter:latest]
+  loadwright doctor [--deep] [--image justb4/jmeter:5.6.3]
   loadwright version
   loadwright init [path]
   loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
@@ -235,7 +236,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		JTLName:    jtlName,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "jmeter run failed: %v\n", err)
+		writeRuntimeError(stderr, err)
 		return 1
 	}
 
@@ -281,6 +282,24 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func writeRuntimeError(stderr io.Writer, err error) {
+	var runtimeErr *runtime.RuntimeError
+	if !errors.As(err, &runtimeErr) {
+		fmt.Fprintf(stderr, "jmeter run failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(stderr, "%s: %s\n", runtimeErr.Kind, runtimeErr.Image)
+	if runtimeErr.Cause != nil {
+		fmt.Fprintf(stderr, "cause: %v\n", runtimeErr.Cause)
+	}
+	if detail := strings.TrimSpace(runtimeErr.Output); detail != "" {
+		fmt.Fprintf(stderr, "docker output: %s\n", strings.Join(strings.Fields(detail), " "))
+	}
+	if runtimeErr.Recovery != "" {
+		fmt.Fprintf(stderr, "recovery: %s\n", runtimeErr.Recovery)
+	}
 }
 
 type runManifest struct {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -60,7 +60,7 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, `Loadwright: Docker-first, spec-driven JMeter automation
 
 Usage:
-  loadwright doctor [--deep] [--image justb4/jmeter:5.6.3]
+  loadwright doctor [--deep] [--image IMAGE]
   loadwright version
   loadwright init [path]
   loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -667,7 +667,7 @@ thresholds:
 	if manifest.JMX != filepath.ToSlash(filepath.Join("results", "smoke", "shim-run.jmx")) {
 		t.Fatalf("unexpected JMX path: %+v", manifest)
 	}
-	if manifest.Image != "justb4/jmeter:latest" || !manifest.CI {
+	if manifest.Image != "justb4/jmeter:5.6.3" || !manifest.CI {
 		t.Fatalf("unexpected run flags: %+v", manifest)
 	}
 	if manifest.Artifacts.ReportHTML != filepath.ToSlash(filepath.Join("results", "smoke", "index.html")) ||
@@ -837,6 +837,172 @@ requests:
 	}
 }
 
+func TestRunReportsDockerDaemonFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "Cannot connect to the Docker daemon" >&2
+  exit 1
+fi
+exit 0
+`)
+	if err := os.WriteFile("existing.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "existing.jmx", "--out-dir", "results/docker-down"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "docker unavailable: justb4/jmeter:5.6.3") ||
+		!strings.Contains(stderr.String(), "Start Docker Desktop") {
+		t.Fatalf("expected actionable docker failure, got stderr=%s", stderr.String())
+	}
+}
+
+func TestDoctorReportsStoppedDockerDaemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "Cannot connect to the Docker daemon" >&2
+  exit 1
+fi
+if [ "$1" = "image" ]; then
+  exit 1
+fi
+if [ "$1" = "pull" ]; then
+  echo "Cannot connect to the Docker daemon" >&2
+  exit 1
+fi
+exit 0
+`)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"doctor"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(doctor) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Docker daemon") ||
+		!strings.Contains(stdout.String(), "Start Docker Desktop") ||
+		!strings.Contains(stdout.String(), "docker version") {
+		t.Fatalf("expected actionable doctor output, got stdout=%s", stdout.String())
+	}
+}
+
+func TestRunReportsImagePullFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "image" ]; then
+  exit 1
+fi
+if [ "$1" = "pull" ]; then
+  echo "manifest unknown" >&2
+  exit 1
+fi
+exit 0
+`)
+	if err := os.WriteFile("existing.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "existing.jmx", "--out-dir", "results/pull-fail", "--image", "missing:jmeter"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "image pull failed: missing:jmeter") ||
+		!strings.Contains(stderr.String(), "manifest unknown") {
+		t.Fatalf("expected image pull failure, got stderr=%s", stderr.String())
+	}
+}
+
+func TestRunReportsJMeterStartupFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "image" ]; then
+  exit 0
+fi
+if [ "$1" = "run" ]; then
+  echo "java: command not found" >&2
+  exit 1
+fi
+exit 0
+`)
+	if err := os.WriteFile("existing.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "existing.jmx", "--out-dir", "results/startup-fail"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "jmeter startup failed: justb4/jmeter:5.6.3") ||
+		!strings.Contains(stderr.String(), "loadwright doctor --deep") {
+		t.Fatalf("expected startup failure, got stderr=%s", stderr.String())
+	}
+}
+
+func TestRunReportsTestExecutionFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "image" ]; then
+  exit 0
+fi
+last=""
+for arg in "$@"; do
+  last="$arg"
+done
+if [ "$1" = "run" ] && [ "$last" = "--version" ]; then
+  echo "Apache JMeter 5.6.3"
+  exit 0
+fi
+echo "CannotResolveClassException: eu.luminis.jmeter.wssampler.OpenWebSocketSampler" >&2
+exit 1
+`)
+	if err := os.WriteFile("websocket.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "websocket.jmx", "--out-dir", "results/test-fail"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "test execution failed: justb4/jmeter:5.6.3") ||
+		!strings.Contains(stderr.String(), "WebSocket specs require an image") {
+		t.Fatalf("expected test execution failure, got stderr=%s", stderr.String())
+	}
+}
+
 func chdir(t *testing.T, dir string) {
 	t.Helper()
 	previous, err := os.Getwd()
@@ -887,6 +1053,25 @@ func installDockerShim(t *testing.T, dir string) {
 	}
 	script := `#!/bin/sh
 set -eu
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "image" ]; then
+  echo "sha256:fake"
+  exit 0
+fi
+if [ "$1" = "pull" ]; then
+  exit 0
+fi
+last=""
+for arg in "$@"; do
+  last="$arg"
+done
+if [ "$1" = "run" ] && [ "$last" = "--version" ]; then
+  echo "Apache JMeter 5.6.3"
+  exit 0
+fi
 workdir=""
 jtl=""
 while [ "$#" -gt 0 ]; do
@@ -918,6 +1103,27 @@ timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success
 1,120,health,200,OK,thread-1,text,true,64,64,1,1,https://example.com/health,100,0,20
 JTL
 `
+	dockerPath := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previousPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+previousPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Setenv("PATH", previousPath); err != nil {
+			t.Fatalf("restore PATH: %v", err)
+		}
+	})
+}
+
+func installFailingDockerShim(t *testing.T, dir string, script string) {
+	t.Helper()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	dockerPath := filepath.Join(binDir, "docker")
 	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1055,15 +1055,16 @@ fi
 echo "CannotResolveClassException: eu.luminis.jmeter.wssampler.OpenWebSocketSampler" >&2
 exit 1
 `)
-	if err := os.WriteFile("websocket.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
+	if err := os.WriteFile("checkout-flow.jmx", []byte("<jmeterTestPlan/>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"run", "websocket.jmx", "--out-dir", "results/test-fail"}, &stdout, &stderr)
+	code := Run([]string{"run", "checkout-flow.jmx", "--out-dir", "results/test-fail"}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "test execution failed: justb4/jmeter:5.6.3") ||
+		!strings.Contains(stderr.String(), "CannotResolveClassException") ||
 		!strings.Contains(stderr.String(), "WebSocket specs require an image") {
 		t.Fatalf("expected test execution failure, got stderr=%s", stderr.String())
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -686,7 +686,7 @@ thresholds:
 	if manifest.JMX != filepath.ToSlash(filepath.Join("results", "smoke", "shim-run.jmx")) {
 		t.Fatalf("unexpected JMX path: %+v", manifest)
 	}
-	if manifest.Image != "justb4/jmeter:5.6.3" || !manifest.CI {
+	if manifest.Image != "justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7" || !manifest.CI {
 		t.Fatalf("unexpected run flags: %+v", manifest)
 	}
 	if manifest.Artifacts.ReportHTML != filepath.ToSlash(filepath.Join("results", "smoke", "index.html")) ||
@@ -924,7 +924,7 @@ exit 0
 	if code != 1 {
 		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "docker unavailable: justb4/jmeter:5.6.3") ||
+	if !strings.Contains(stderr.String(), "docker unavailable: justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7") ||
 		!strings.Contains(stderr.String(), "Start Docker Desktop") {
 		t.Fatalf("expected actionable docker failure, got stderr=%s", stderr.String())
 	}
@@ -1024,7 +1024,7 @@ exit 0
 	if code != 1 {
 		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "jmeter startup failed: justb4/jmeter:5.6.3") ||
+	if !strings.Contains(stderr.String(), "jmeter startup failed: justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7") ||
 		!strings.Contains(stderr.String(), "loadwright doctor --deep") {
 		t.Fatalf("expected startup failure, got stderr=%s", stderr.String())
 	}
@@ -1063,7 +1063,7 @@ exit 1
 	if code != 1 {
 		t.Fatalf("Run(run) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "test execution failed: justb4/jmeter:5.6.3") ||
+	if !strings.Contains(stderr.String(), "test execution failed: justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7") ||
 		!strings.Contains(stderr.String(), "CannotResolveClassException") ||
 		!strings.Contains(stderr.String(), "WebSocket specs require an image") {
 		t.Fatalf("expected test execution failure, got stderr=%s", stderr.String())

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -11,7 +11,45 @@ import (
 	"strings"
 )
 
-const DefaultJMeterImage = "justb4/jmeter:latest"
+const DefaultJMeterImage = "justb4/jmeter:5.6.3"
+
+type ErrorKind string
+
+const (
+	ErrorDockerUnavailable ErrorKind = "docker unavailable"
+	ErrorImagePull         ErrorKind = "image pull failed"
+	ErrorJMeterStartup     ErrorKind = "jmeter startup failed"
+	ErrorTestExecution     ErrorKind = "test execution failed"
+)
+
+type RuntimeError struct {
+	Kind     ErrorKind
+	Image    string
+	Cause    error
+	Output   string
+	Recovery string
+}
+
+func (e *RuntimeError) Error() string {
+	if e == nil {
+		return ""
+	}
+	message := string(e.Kind)
+	if e.Image != "" {
+		message += " for image " + e.Image
+	}
+	if e.Cause != nil {
+		message += ": " + e.Cause.Error()
+	}
+	return message
+}
+
+func (e *RuntimeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
 
 type RunOptions struct {
 	Image      string
@@ -79,6 +117,15 @@ func RunJMeter(options RunOptions) error {
 	if err != nil || relJMX == "." || relJMX == ".." || strings.HasPrefix(relJMX, ".."+string(filepath.Separator)) {
 		return errors.New("JMX file must be inside the working directory")
 	}
+	if err := requireDockerDaemon(options.Image); err != nil {
+		return err
+	}
+	if err := ensureImage(options.Image); err != nil {
+		return err
+	}
+	if err := probeJMeterStartup(options.Image); err != nil {
+		return err
+	}
 
 	args := []string{
 		"run", "--rm",
@@ -92,7 +139,15 @@ func RunJMeter(options RunOptions) error {
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return &RuntimeError{
+			Kind:     ErrorTestExecution,
+			Image:    options.Image,
+			Cause:    err,
+			Recovery: testExecutionRecovery(relJMX),
+		}
+	}
+	return nil
 }
 
 func checkCommand(command string, name string) Check {
@@ -104,9 +159,13 @@ func checkCommand(command string, name string) Check {
 
 func checkDocker() Check {
 	cmd := exec.Command("docker", "version", "--format", "{{.Server.Version}}")
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return Check{Name: "Docker daemon", Passed: false, Message: "docker daemon is not reachable"}
+		message := "Docker CLI is installed, but the Docker daemon is not reachable. Start Docker Desktop or your Docker service, then run `docker version` and retry."
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			message += " Docker said: " + oneLine(detail)
+		}
+		return Check{Name: "Docker daemon", Passed: false, Message: message}
 	}
 	return Check{Name: "Docker daemon", Passed: true, Message: "server " + stringTrim(output)}
 }
@@ -127,9 +186,18 @@ func checkWritableDir(path string, name string) Check {
 
 func checkImage(image string) Check {
 	cmd := exec.Command("docker", "image", "inspect", image, "--format", "{{.Architecture}}")
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return Check{Name: "JMeter image", Passed: true, Message: image + " not local; Docker will pull it on first run"}
+		pull := exec.Command("docker", "pull", image)
+		pullOutput, pullErr := pull.CombinedOutput()
+		if pullErr != nil {
+			message := fmt.Sprintf("could not pull %s. Check network access, registry auth, and the image tag.", image)
+			if detail := strings.TrimSpace(string(pullOutput)); detail != "" {
+				message += " Docker said: " + oneLine(detail)
+			}
+			return Check{Name: "JMeter image", Passed: false, Message: message}
+		}
+		return Check{Name: "JMeter image", Passed: true, Message: image + " pulled successfully"}
 	}
 	arch := stringTrim(output)
 	message := image + " available"
@@ -140,16 +208,92 @@ func checkImage(image string) Check {
 }
 
 func checkJMeterRuntime(image string) Check {
-	cmd := exec.Command("docker", "run", "--rm", image, "--version")
-	output, err := cmd.CombinedOutput()
+	output, err := runJMeterVersion(image)
 	if err != nil {
-		return Check{Name: "JMeter runtime", Passed: false, Message: err.Error()}
+		message := fmt.Sprintf("Docker started %s but JMeter did not report a version.", image)
+		if detail := strings.TrimSpace(output); detail != "" {
+			message += " Output: " + oneLine(detail)
+		}
+		return Check{Name: "JMeter runtime", Passed: false, Message: message}
 	}
-	version := firstVersionLine(string(output))
+	version := firstVersionLine(output)
 	if version == "" {
 		version = "started successfully"
 	}
 	return Check{Name: "JMeter runtime", Passed: true, Message: version}
+}
+
+func requireDockerDaemon(image string) error {
+	cmd := exec.Command("docker", "version", "--format", "{{.Server.Version}}")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	return &RuntimeError{
+		Kind:     ErrorDockerUnavailable,
+		Image:    image,
+		Cause:    err,
+		Output:   string(output),
+		Recovery: "Start Docker Desktop or your Docker service, confirm `docker version` shows a Server version, then retry `loadwright run`.",
+	}
+}
+
+func ensureImage(image string) error {
+	inspect := exec.Command("docker", "image", "inspect", image, "--format", "{{.Id}}")
+	if err := inspect.Run(); err == nil {
+		return nil
+	}
+	pull := exec.Command("docker", "pull", image)
+	output, err := pull.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	return &RuntimeError{
+		Kind:     ErrorImagePull,
+		Image:    image,
+		Cause:    err,
+		Output:   string(output),
+		Recovery: "Check your network, registry credentials, and image tag. You can override the runtime with `loadwright run ... --image <image:tag>`.",
+	}
+}
+
+func probeJMeterStartup(image string) error {
+	output, err := runJMeterVersion(image)
+	if err == nil && firstVersionLine(output) != "" {
+		return nil
+	}
+	if err == nil {
+		err = errors.New("JMeter version was not found in container output")
+	}
+	return &RuntimeError{
+		Kind:     ErrorJMeterStartup,
+		Image:    image,
+		Cause:    err,
+		Output:   output,
+		Recovery: "Run `loadwright doctor --deep` for the same image. If this is a custom image, verify it can run `jmeter --version` or `--version` successfully.",
+	}
+}
+
+func runJMeterVersion(image string) (string, error) {
+	cmd := exec.Command("docker", "run", "--rm", image, "--version")
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func testExecutionRecovery(relJMX string) string {
+	message := fmt.Sprintf("Docker and JMeter started, but the test plan %s failed during execution. Check the generated jmeter.log in the results directory when available.", filepath.ToSlash(relJMX))
+	if strings.Contains(relJMX, "websocket") {
+		message += " WebSocket specs require an image with the WebSocket Samplers plugin, for example the image built from docker/jmeter/Dockerfile."
+	}
+	return message
+}
+
+func oneLine(value string) string {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Join(fields, " ")
 }
 
 func firstVersionLine(output string) string {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -137,14 +137,17 @@ func RunJMeter(options RunOptions) error {
 		"-l", "/work/" + filepath.ToSlash(filepath.Join(mustRel(absWorkDir, resultsAbs), options.JTLName)),
 	}
 	cmd := exec.Command("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		_, _ = os.Stderr.Write(output)
+	}
+	if err != nil {
 		return &RuntimeError{
 			Kind:     ErrorTestExecution,
 			Image:    options.Image,
 			Cause:    err,
-			Recovery: testExecutionRecovery(relJMX),
+			Output:   string(output),
+			Recovery: testExecutionRecovery(string(output)),
 		}
 	}
 	return nil
@@ -280,12 +283,18 @@ func runJMeterVersion(image string) (string, error) {
 	return string(output), err
 }
 
-func testExecutionRecovery(relJMX string) string {
-	message := fmt.Sprintf("Docker and JMeter started, but the test plan %s failed during execution. Check the generated jmeter.log in the results directory when available.", filepath.ToSlash(relJMX))
-	if strings.Contains(relJMX, "websocket") {
+func testExecutionRecovery(output string) string {
+	message := "Docker and JMeter started, but the test plan failed during execution. Check the generated jmeter.log in the results directory when available."
+	if looksLikeMissingWebSocketPlugin(output) {
 		message += " WebSocket specs require an image with the WebSocket Samplers plugin, for example the image built from docker/jmeter/Dockerfile."
 	}
 	return message
+}
+
+func looksLikeMissingWebSocketPlugin(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "cannotresolveclassexception") &&
+		strings.Contains(lower, "eu.luminis.jmeter.wssampler")
 }
 
 func oneLine(value string) string {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +13,7 @@ import (
 	"strings"
 )
 
-const DefaultJMeterImage = "justb4/jmeter:5.6.3"
+const DefaultJMeterImage = "justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7"
 
 type ErrorKind string
 
@@ -137,17 +139,18 @@ func RunJMeter(options RunOptions) error {
 		"-l", "/work/" + filepath.ToSlash(filepath.Join(mustRel(absWorkDir, resultsAbs), options.JTLName)),
 	}
 	cmd := exec.Command("docker", args...)
-	output, err := cmd.CombinedOutput()
-	if len(output) > 0 {
-		_, _ = os.Stderr.Write(output)
-	}
-	if err != nil {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	if err := cmd.Run(); err != nil {
+		output := stdout.String() + stderr.String()
 		return &RuntimeError{
 			Kind:     ErrorTestExecution,
 			Image:    options.Image,
 			Cause:    err,
-			Output:   string(output),
-			Recovery: testExecutionRecovery(string(output)),
+			Output:   output,
+			Recovery: testExecutionRecovery(output),
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #26

## Summary
- Pin the default JMeter runtime image to a tested tag
- Improve doctor output for Docker daemon, image pull, and JMeter startup failures
- Add typed runtime errors and actionable run failure guidance
- Document the supported JMeter image policy and WebSocket image requirement
- Add tests for runtime failure formatting

## Tests
- GOCACHE="$PWD/.gocache" GOPATH="$PWD/.gopath" /usr/local/go/bin/go test ./...