### PR TITLE
docs(onboarding): polish first-run experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-No unreleased changes.
+- Polish the first-run documentation journey for the `v0.2.0` release.
+- Add next-step guidance after `loadwright init` creates a starter spec.
 
 ## 0.2.0 - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ It is not a new load-testing engine. It is a small automation layer that keeps J
 
 ## Project Status
 
-Loadwright is at `v0.1.0`. It is usable for HTTP API load-test workflows and CI smoke/performance checks, but the public API and YAML spec may still evolve before `v1.0.0`.
+Loadwright is at `v0.2.0`. It is usable for HTTP API, WebSocket API, and CI smoke/performance checks, but the public API and YAML spec may still evolve before `v1.0.0`.
 
-The current development scope is intentionally focused: HTTP requests, WebSocket requests, JSON/text/form bodies, Dockerized JMeter execution, OpenAPI/Postman/HAR bootstrapping, CSV data, thresholds, and reports. Plugin management, distributed runners, and AI-assisted workflows are planned later.
+The current development scope is intentionally focused: HTTP requests, WebSocket requests, JSON/text/urlencoded/multipart bodies, Dockerized JMeter execution, OpenAPI/Postman/HAR bootstrapping, CSV data, thresholds, and reports. Automated plugin management, distributed runners, and AI-assisted workflows are planned later.
 
 ## Why This Exists
 
@@ -32,38 +32,46 @@ Use Loadwright when you want:
 - HAR-to-spec bootstrapping from browser/API traffic captures
 - future optional AI assistance without depending on AI for normal runs
 
-Current `v0.1.0` scope: API load tests (HTTP and WebSocket). See [docs/limitations.md](docs/limitations.md) for known limits.
+Current `v0.2.0` scope: API load tests (HTTP and WebSocket). See [docs/limitations.md](docs/limitations.md) for known limits.
 
-## Install From Source
+## Install
 
-Requires Go 1.22+ and Docker.
+Install the latest release binary from [GitHub Releases](https://github.com/devaryakjha/loadwright/releases), or use Go:
+
+```bash
+go install github.com/devaryakjha/loadwright/cmd/loadwright@v0.2.0
+```
+
+From a source checkout:
 
 ```bash
 go build -o bin/loadwright ./cmd/loadwright
 ```
 
+Docker is required for `loadwright run` and `loadwright doctor --deep`. It is not required for `init`, `validate`, `compile`, `import`, or `report`.
+
 ## Quickstart
 
-Create a starter spec:
+Check the CLI and local prerequisites:
 
 ```bash
-bin/loadwright init
+loadwright version
+loadwright doctor
 ```
 
-Or use the included example:
+Create a starter spec, then validate and compile it without starting Docker:
 
 ```bash
-bin/loadwright doctor
-bin/loadwright validate examples/api/basic.yaml
-bin/loadwright compile examples/api/basic.yaml -o tests/httpbin-basic.jmx
-bin/loadwright run examples/api/basic.yaml --ci
+loadwright init
+loadwright validate loadwright.yaml
+loadwright compile loadwright.yaml
 ```
 
-Check local prerequisites:
+Run the starter spec through Dockerized JMeter:
 
 ```bash
-bin/loadwright doctor
-bin/loadwright doctor --deep
+loadwright doctor --deep
+loadwright run loadwright.yaml --ci
 ```
 
 Reports are written to `results/<run-id>/`:
@@ -76,6 +84,13 @@ Reports are written to `results/<run-id>/`:
 - `run.json`
 
 Default runs also update `results/latest.json` so the newest report can be found without copying the timestamped run ID.
+
+From a source checkout, you can also run the included examples:
+
+```bash
+loadwright validate examples/api/basic.yaml
+loadwright run examples/api/basic.yaml --ci
+```
 
 ## Example Spec
 
@@ -104,6 +119,7 @@ More docs:
 - [Getting started](docs/getting-started.md)
 - [Install](docs/install.md)
 - [Examples](docs/examples.md)
+- [Troubleshooting](docs/troubleshooting.md)
 - [OpenAPI import](docs/openapi-import.md)
 - [Postman import](docs/postman-import.md)
 - [HAR import](docs/har-import.md)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,6 +24,13 @@ justb4/jmeter:latest
 
 Use `loadwright doctor --deep` to verify that the configured image starts on your machine.
 
+WebSocket specs require the bundled plugin-enabled image until plugin setup is automated:
+
+```bash
+docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
+loadwright doctor --deep --image loadwright/jmeter-websocket:latest
+```
+
 ## Docker
 
 Docker is required for `loadwright run` and `loadwright doctor --deep`.
@@ -34,6 +41,8 @@ Docker is not required for:
 - `loadwright validate`
 - `loadwright compile`
 - `loadwright import openapi`
+- `loadwright import postman`
+- `loadwright import har`
 - `loadwright report`
 
 ## Spec Stability

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,6 +2,8 @@
 
 The `examples/` directory contains runnable specs for common scenarios.
 
+Run `loadwright doctor --deep` once before running HTTP examples for the first time. WebSocket examples need the plugin-enabled image shown in the WebSocket section.
+
 ## Basic API
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,28 +2,39 @@
 
 Loadwright is a Go CLI for running JMeter from readable YAML specs.
 
-## Build
+## Install
 
-```bash
-go build -o bin/loadwright ./cmd/loadwright
-```
+Install `loadwright` from [GitHub Releases](https://github.com/devaryakjha/loadwright/releases/tag/v0.2.0), with `go install github.com/devaryakjha/loadwright/cmd/loadwright@v0.2.0`, or from a source checkout with `go build -o bin/loadwright ./cmd/loadwright`.
+
+The commands below assume `loadwright` is on your `PATH`. If you built from source and did not install the binary, use `bin/loadwright` instead.
 
 ## Check Your Machine
 
 ```bash
-bin/loadwright doctor
+loadwright version
+loadwright doctor
 ```
 
 For a stronger check that starts JMeter through Docker:
 
 ```bash
-bin/loadwright doctor --deep
+loadwright doctor --deep
 ```
 
-## Run The Basic Example
+## Validate And Compile First
+
+Create a starter spec. Then validate and compile it before running. These commands do not start Docker, so they are the fastest way to verify the spec path:
 
 ```bash
-bin/loadwright run examples/api/basic.yaml --ci
+loadwright init
+loadwright validate loadwright.yaml
+loadwright compile loadwright.yaml
+```
+
+## Run The Starter Spec
+
+```bash
+loadwright run loadwright.yaml --ci
 ```
 
 The run writes artifacts to `results/<run-id>/`:
@@ -40,7 +51,7 @@ Default runs also update `results/latest.json`, and create a best-effort `result
 ## Compile Without Running
 
 ```bash
-bin/loadwright compile examples/api/basic.yaml -o tests/httpbin-basic.jmx
+loadwright compile loadwright.yaml -o tests/example-api.jmx
 ```
 
 The generated `.jmx` file can be opened in the JMeter GUI or run by JMeter directly.
@@ -48,16 +59,28 @@ The generated `.jmx` file can be opened in the JMeter GUI or run by JMeter direc
 ## Validate Without Running
 
 ```bash
-bin/loadwright validate examples/api/basic.yaml
+loadwright validate loadwright.yaml
 ```
 
 Validation resolves variables and env files, applies defaults, and reports spec errors without starting Docker or JMeter.
 
 ## Env Files
 
-Specs can reference environment values with `${NAME}` and variables with `{{name}}`.
+Specs can reference environment values with `${NAME}` and variables with `{{name}}`. From a source checkout, try the included env-file example:
 
 ```bash
-bin/loadwright validate examples/api/env-file.yaml --env-file examples/api/.env.example
-bin/loadwright run examples/api/env-file.yaml --env-file examples/api/.env.example --ci
+loadwright validate examples/api/env-file.yaml --env-file examples/api/.env.example
+loadwright run examples/api/env-file.yaml --env-file examples/api/.env.example --ci
 ```
+
+## Create Your Own Spec
+
+If you already used `loadwright init`, edit `loadwright.yaml` and rerun:
+
+```bash
+loadwright validate loadwright.yaml
+loadwright compile loadwright.yaml
+loadwright run loadwright.yaml --ci
+```
+
+If any first-run command fails, see [Troubleshooting](troubleshooting.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,27 +1,12 @@
 # Install
 
-Loadwright can be installed from source today. Tagged releases will publish binaries, checksums, and container images.
+Loadwright publishes release binaries, checksums, and a Go module.
 
-## Go Install
-
-```bash
-go install github.com/devaryakjha/loadwright/cmd/loadwright@latest
-```
-
-For a specific version:
-
-```bash
-go install github.com/devaryakjha/loadwright/cmd/loadwright@v0.1.0
-```
-
-## Build From Source
-
-```bash
-go build -o bin/loadwright ./cmd/loadwright
-bin/loadwright version
-```
+The current public release is `v0.2.0`.
 
 ## GitHub Releases
+
+Download the archive for your operating system from [GitHub Releases](https://github.com/devaryakjha/loadwright/releases/tag/v0.2.0).
 
 Release artifacts are produced for:
 
@@ -31,12 +16,63 @@ Release artifacts are produced for:
 
 Each release includes `checksums.txt`.
 
-## Docker
+Example for macOS arm64:
 
-The container image is useful for compile/import/report workflows that do not need to start Dockerized JMeter from inside the container.
+```bash
+curl -L -o loadwright.tar.gz https://github.com/devaryakjha/loadwright/releases/download/v0.2.0/loadwright_0.2.0_darwin_arm64.tar.gz
+tar -xzf loadwright.tar.gz
+./loadwright version
+```
+
+## Go Install
+
+```bash
+go install github.com/devaryakjha/loadwright/cmd/loadwright@v0.2.0
+```
+
+`go install` builds from source, so `loadwright version` may show development metadata. Use the GitHub release archives when you need the exact release version, commit, and build date embedded in the binary.
+
+For the latest commit on the default branch:
+
+```bash
+go install github.com/devaryakjha/loadwright/cmd/loadwright@latest
+```
+
+## Build From Source
+
+```bash
+go build -o bin/loadwright ./cmd/loadwright
+bin/loadwright version
+```
+
+## Container Image
+
+The release workflow builds `ghcr.io/devaryakjha/loadwright`, but the recommended first-run path is the release binary or `go install`.
+
+Use the container image only after verifying that your environment can pull it:
+
+```bash
+docker pull ghcr.io/devaryakjha/loadwright:latest
+```
+
+If the pull succeeds, the image is useful for compile/import/report workflows that do not need to start Dockerized JMeter from inside the container. From a source checkout:
 
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" ghcr.io/devaryakjha/loadwright:latest compile examples/api/basic.yaml
 ```
 
 Running load tests from inside the container requires a Docker strategy that will be documented separately.
+
+## First Check
+
+After installing, create and check a starter spec:
+
+```bash
+loadwright version
+loadwright doctor
+loadwright init
+loadwright validate loadwright.yaml
+loadwright compile loadwright.yaml
+```
+
+Use `loadwright doctor --deep` before your first `loadwright run` to verify Docker can start JMeter.

--- a/docs/release.md
+++ b/docs/release.md
@@ -47,7 +47,7 @@ Pushing the tag triggers `.github/workflows/release.yml`, which publishes GitHub
 
 - Confirm the GitHub Release has archives for macOS, Linux, and Windows.
 - Confirm `checksums.txt` exists.
-- Confirm the container image exists in GHCR.
+- Confirm the container image exists in GHCR and is publicly pullable before documenting it as an install path.
 - Run a downloaded binary with `loadwright version`.
 - Confirm `summary.json`, `summary.md`, `index.html`, and `junit.xml` are produced by the release smoke test.
 - Create a follow-up issue for anything deferred from the release.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,76 @@
+# Troubleshooting
+
+Use this page when the quickstart fails before you get a report.
+
+## Docker Is Not Running
+
+`loadwright doctor` checks that the Docker CLI exists. `loadwright doctor --deep` also starts the configured JMeter image.
+
+If `doctor --deep` fails before JMeter starts:
+
+```bash
+docker version
+docker info
+loadwright doctor --deep
+```
+
+Start Docker Desktop or your Docker daemon, then rerun `loadwright doctor --deep`.
+
+## Image Pull Or Startup Fails
+
+Loadwright uses `justb4/jmeter:latest` by default for HTTP runs.
+
+```bash
+docker pull justb4/jmeter:latest
+loadwright doctor --deep --image justb4/jmeter:latest
+```
+
+If your environment blocks public image pulls, mirror the image internally and pass it with `--image`:
+
+```bash
+loadwright run loadwright.yaml --ci --image registry.example.com/jmeter:5.6
+```
+
+## Permission Or Output Errors
+
+`loadwright run` writes reports under `results/` unless `--out-dir` is provided.
+
+```bash
+mkdir -p results
+loadwright run loadwright.yaml --out-dir results/basic-smoke --ci
+```
+
+For containerized compile/import/report commands, first verify that your environment can pull the Loadwright image:
+
+```bash
+docker pull ghcr.io/devaryakjha/loadwright:latest
+```
+
+If the pull succeeds, mount a writable working directory and run as your local user. From a source checkout:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" ghcr.io/devaryakjha/loadwright:latest compile examples/api/basic.yaml
+```
+
+If Docker reports `unauthorized`, use the release binary or `go install` path instead.
+
+## WebSocket Examples
+
+WebSocket specs currently require the bundled plugin-enabled JMeter image.
+
+```bash
+docker build -t loadwright/jmeter-websocket:latest -f docker/jmeter/Dockerfile .
+loadwright doctor --deep --image loadwright/jmeter-websocket:latest
+loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:latest
+```
+
+HTTP examples do not require this WebSocket image.
+
+## Validate Before Running
+
+If a spec fails during a run, validate and compile it first. These commands do not start Docker:
+
+```bash
+loadwright validate loadwright.yaml
+loadwright compile loadwright.yaml
+```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -140,7 +140,22 @@ func initSpec(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "created %s\n", path)
+	quotedPath := shellArg(path)
+	fmt.Fprintf(stdout, "\nNext steps:\n")
+	fmt.Fprintf(stdout, "  loadwright validate %s\n", quotedPath)
+	fmt.Fprintf(stdout, "  loadwright compile %s\n", quotedPath)
+	fmt.Fprintf(stdout, "  loadwright run %s --ci\n", quotedPath)
 	return 0
+}
+
+func shellArg(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(value, " \t\n'\"\\$`!#&();<>|*?[]{}") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func compile(args []string, stdout io.Writer, stderr io.Writer) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -208,6 +208,24 @@ func TestRunInitCreatesStarterSpec(t *testing.T) {
 	if !strings.Contains(string(data), "name: example-api") {
 		t.Fatalf("unexpected starter spec: %s", data)
 	}
+	if !strings.Contains(stdout.String(), "loadwright validate loadwright.yaml") ||
+		!strings.Contains(stdout.String(), "loadwright run loadwright.yaml --ci") {
+		t.Fatalf("init output did not include next steps: %s", stdout.String())
+	}
+}
+
+func TestRunInitQuotesNextStepPath(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"init", "first spec.yaml"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(init) code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "loadwright validate 'first spec.yaml'") ||
+		!strings.Contains(stdout.String(), "loadwright run 'first spec.yaml' --ci") {
+		t.Fatalf("init output did not quote path: %s", stdout.String())
+	}
 }
 
 func TestRunCompileCreatesJMX(t *testing.T) {


### PR DESCRIPTION
## Summary
- update README/install/getting-started docs for the v0.2.0 release and standalone init-first quickstart
- add troubleshooting guidance for Docker, image pulls, permissions, WebSocket setup, and validation-before-run
- add next-step guidance after loadwright init creates a starter spec
- make container image docs honest after GHCR public pull validation failed

Closes #28
Follow-up: #32

## Validation
- go test ./...
- go vet ./...
- git diff --check
- fresh temp quickstart with local build: version, doctor, init, validate, compile, run --ci (30 samples, 0 errors)
- downloaded v0.2.0 darwin arm64 release archive and ran loadwright version
- go install github.com/devaryakjha/loadwright/cmd/loadwright@v0.2.0 and ran loadwright version
- docker pull/run ghcr.io/devaryakjha/loadwright:latest currently fails with unauthorized; filed #32 and adjusted docs to avoid presenting it as the recommended first-run path