### PR TITLE
ci(release): verify public GHCR pulls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify public GHCR pull
+        run: |
+          scripts/verify-ghcr-public-pull.sh "ghcr.io/devaryakjha/loadwright:${GITHUB_REF_NAME#v}"
+          scripts/verify-ghcr-public-pull.sh ghcr.io/devaryakjha/loadwright:latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,7 @@ archives:
       - CHANGELOG.md
       - docs/*
       - examples/**/*
+      - scripts/*
 
 checksum:
   name_template: "checksums.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Polish the first-run documentation journey for the `v0.2.0` release.
 - Add next-step guidance after `loadwright init` creates a starter spec.
+- Add anonymous GHCR pull verification for release container images.
 
 ## 0.2.0 - 2026-05-24
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,10 +49,10 @@ bin/loadwright version
 
 The release workflow builds `ghcr.io/devaryakjha/loadwright`, but the recommended first-run path is the release binary or `go install`.
 
-Use the container image only after verifying that your environment can pull it:
+The container image is intended to be publicly pullable. From a source checkout or release archive, verify anonymous access before using it:
 
 ```bash
-docker pull ghcr.io/devaryakjha/loadwright:latest
+scripts/verify-ghcr-public-pull.sh ghcr.io/devaryakjha/loadwright:latest
 ```
 
 If the pull succeeds, the image is useful for compile/import/report workflows that do not need to start Dockerized JMeter from inside the container. From a source checkout:
@@ -60,6 +60,8 @@ If the pull succeeds, the image is useful for compile/import/report workflows th
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" ghcr.io/devaryakjha/loadwright:latest compile examples/api/basic.yaml
 ```
+
+If the verification fails with `unauthorized`, publish again from the public repository release workflow or adjust the package visibility/access settings in GitHub Packages before documenting the container as an install path.
 
 Running load tests from inside the container requires a Docker strategy that will be documented separately.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -47,7 +47,11 @@ Pushing the tag triggers `.github/workflows/release.yml`, which publishes GitHub
 
 - Confirm the GitHub Release has archives for macOS, Linux, and Windows.
 - Confirm `checksums.txt` exists.
-- Confirm the container image exists in GHCR and is publicly pullable before documenting it as an install path.
+- Confirm the container image exists in GHCR and is publicly pullable:
+  ```bash
+  scripts/verify-ghcr-public-pull.sh ghcr.io/devaryakjha/loadwright:latest
+  ```
+  If this fails with `unauthorized`, first confirm the current release workflow published after the repository became public. If a fresh public-repo publish still fails, open the `loadwright` package under the GitHub profile's Packages tab and adjust the package visibility/access settings.
 - Run a downloaded binary with `loadwright version`.
 - Confirm `summary.json`, `summary.md`, `index.html`, and `junit.xml` are produced by the release smoke test.
 - Create a follow-up issue for anything deferred from the release.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,10 +40,10 @@ mkdir -p results
 loadwright run loadwright.yaml --out-dir results/basic-smoke --ci
 ```
 
-For containerized compile/import/report commands, first verify that your environment can pull the Loadwright image:
+For containerized compile/import/report commands, first verify that your environment can anonymously pull the Loadwright image. From a source checkout or release archive:
 
 ```bash
-docker pull ghcr.io/devaryakjha/loadwright:latest
+scripts/verify-ghcr-public-pull.sh ghcr.io/devaryakjha/loadwright:latest
 ```
 
 If the pull succeeds, mount a writable working directory and run as your local user. From a source checkout:
@@ -52,7 +52,14 @@ If the pull succeeds, mount a writable working directory and run as your local u
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" ghcr.io/devaryakjha/loadwright:latest compile examples/api/basic.yaml
 ```
 
-If Docker reports `unauthorized`, use the release binary or `go install` path instead.
+If Docker reports `unauthorized`, use the release binary or `go install` path instead. If you intentionally need a private GHCR package, authenticate with a token that has `read:packages` before pulling:
+
+```bash
+echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
+docker pull ghcr.io/devaryakjha/loadwright:latest
+```
+
+For maintainers, an anonymous `unauthorized` response means the container image is not yet publicly pullable. First confirm a release workflow has published after the repository became public. If a fresh public-repo publish still fails, open the `loadwright` package under the GitHub profile's Packages tab and adjust the package visibility/access settings.
 
 ## WebSocket Examples
 

--- a/scripts/verify-ghcr-public-pull.sh
+++ b/scripts/verify-ghcr-public-pull.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:-ghcr.io/devaryakjha/loadwright:latest}"
+docker_config="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$docker_config"
+}
+trap cleanup EXIT
+
+echo "verifying anonymous pull for $image"
+DOCKER_CONFIG="$docker_config" docker pull "$image"


### PR DESCRIPTION
## Summary
- add scripts/verify-ghcr-public-pull.sh, which uses a clean Docker config to prove anonymous GHCR pulls
- run the anonymous pull verifier for the release tag and latest tag after GoReleaser publishes images
- ship the verifier in release archives and document GHCR unauthorized/authenticated fallback behavior

Refs #32

## Important note
This PR cannot flip the existing GitHub Packages visibility setting by itself. Current validation still shows ghcr.io/devaryakjha/loadwright:latest returns unauthorized for anonymous pulls. A maintainer still needs to set the package visibility to public in GitHub Packages; after that, this verifier should pass and future releases will catch regressions.

## Validation
- bash -n scripts/verify-ghcr-public-pull.sh
- git diff --check
- go test ./...
- go vet ./...
- goreleaser check
- scripts/verify-ghcr-public-pull.sh ghcr.io/devaryakjha/loadwright:latest currently fails with unauthorized, as expected before package visibility is changed