### PR TITLE
feat(runtime): automate WebSocket setup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,7 @@ archives:
       - CHANGELOG.md
       - docs/*
       - examples/**/*
+      - docker/jmeter/*
       - scripts/*
 
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Polish the first-run documentation journey for the `v0.2.0` release.
 - Add next-step guidance after `loadwright init` creates a starter spec.
 - Add anonymous GHCR pull verification for release container images.
+- Add `loadwright setup websocket`, `doctor --deep --websocket`, and automatic WebSocket YAML runtime image selection.
 
 ## 0.2.0 - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ From a source checkout:
 go build -o bin/loadwright ./cmd/loadwright
 ```
 
-Docker is required for `loadwright run` and `loadwright doctor --deep`. It is not required for `init`, `validate`, `compile`, `import`, or `report`.
+Docker is required for `loadwright run`, `loadwright setup websocket`, and `loadwright doctor --deep`. It is not required for `init`, `validate`, `compile`, `import`, or `report`.
 
 ## Quickstart
 
@@ -134,7 +134,8 @@ More docs:
 ## Commands
 
 ```bash
-loadwright doctor [--deep] [--image IMAGE]
+loadwright doctor [--deep] [--websocket] [--image IMAGE]
+loadwright setup websocket [--image IMAGE] [--dockerfile docker/jmeter/Dockerfile]
 loadwright version
 loadwright init [path]
 loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
@@ -149,14 +150,15 @@ loadwright compare <baseline-summary.json> <candidate-summary.json> [-o comparis
 
 `doctor --deep` runs the configured JMeter Docker image and verifies that JMeter starts.
 
-For WebSocket specs, build the bundled plugin image first, then pass it with `--image`:
+For WebSocket specs, build the bundled plugin image once, verify it, then run the YAML spec normally:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.5
+bin/loadwright setup websocket
+bin/loadwright doctor --deep --websocket
+bin/loadwright run examples/api/websocket-multi.yaml --ci
 ```
 
-The `docker/jmeter/Dockerfile` extends the pinned HTTP runtime image, `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7`, and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin.
+The `docker/jmeter/Dockerfile` extends the pinned HTTP runtime image, `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7`, and adds the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin pinned in `docker/jmeter/websocket-plugin.lock`. WebSocket YAML specs use `loadwright/jmeter-websocket:5.5` automatically unless you pass `--image`.
 
 ## Roadmap
 
@@ -164,7 +166,7 @@ See [ROADMAP.md](ROADMAP.md). The short version:
 
 - make the deterministic Go CLI excellent first
 - add broader import support next
-- add WebSocket/plugin automation
+- publish and distribute richer runtime images
 - add optional AI later for generating, explaining, and improving specs
 
 ## Development

--- a/docker/jmeter/Dockerfile
+++ b/docker/jmeter/Dockerfile
@@ -1,7 +1,9 @@
 FROM justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
 
-# Install the WebSocket Samplers plugin by Peter Doornbosch (v1.3.2)
+# Install the WebSocket Samplers plugin pinned in websocket-plugin.lock.
+# Plugin by Peter Doornbosch (v1.3.2)
 # https://github.com/ptrd/jmeter-websocket-samplers
 ARG WS_PLUGIN_VERSION=1.3.2
-ADD https://repo1.maven.org/maven2/net/luminis/jmeter/jmeter-websocket-samplers/${WS_PLUGIN_VERSION}/jmeter-websocket-samplers-${WS_PLUGIN_VERSION}.jar \
+ARG WS_PLUGIN_SHA256=f9818f27fbbfe871bc2fb191215970928a475a586c640c7bb29bf76a9d7ced3f
+ADD --checksum=sha256:${WS_PLUGIN_SHA256} https://repo1.maven.org/maven2/net/luminis/jmeter/jmeter-websocket-samplers/${WS_PLUGIN_VERSION}/jmeter-websocket-samplers-${WS_PLUGIN_VERSION}.jar \
     /opt/apache-jmeter-5.5/lib/ext/jmeter-websocket-samplers-${WS_PLUGIN_VERSION}.jar

--- a/docker/jmeter/websocket-plugin.lock
+++ b/docker/jmeter/websocket-plugin.lock
@@ -1,0 +1,6 @@
+plugin=net.luminis.jmeter:jmeter-websocket-samplers
+version=1.3.2
+source=https://repo1.maven.org/maven2/net/luminis/jmeter/jmeter-websocket-samplers/1.3.2/jmeter-websocket-samplers-1.3.2.jar
+sha256=f9818f27fbbfe871bc2fb191215970928a475a586c640c7bb29bf76a9d7ced3f
+base_image=justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7
+local_image=loadwright/jmeter-websocket:5.5

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,17 +24,21 @@ justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930
 
 Loadwright does not use floating `latest` tags as its support boundary. Patch releases may move to a newer immutable image digest after the CLI, generated JMX, and report flow are tested against that image.
 
-HTTP specs use the default image unless `--image` is provided. WebSocket specs require a plugin-enabled image because the generated JMX uses the WebSocket Samplers plugin. Build the bundled image with:
+HTTP specs use the default image unless `--image` is provided. WebSocket YAML specs use `loadwright/jmeter-websocket:5.5` automatically unless `--image` is provided, because the generated JMX uses the WebSocket Samplers plugin.
+
+Build the bundled image with:
 
 ```sh
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
+loadwright setup websocket
 ```
 
-Use `loadwright doctor --deep --image <image:tag>` to verify that the configured image pulls and starts on your machine before running a load test.
+Use `loadwright doctor --deep --websocket` to verify that the configured image starts and includes the pinned plugin before running a WebSocket load test. Custom WebSocket images can still be checked with `loadwright doctor --deep --websocket --image <image:tag>`.
+
+The WebSocket plugin version, Maven source URL, checksum, base image, and local image tag are recorded in `docker/jmeter/websocket-plugin.lock`.
 
 ## Docker
 
-Docker is required for `loadwright run`, `loadwright doctor`, and `loadwright doctor --deep`. The basic doctor checks verify the Docker CLI, daemon reachability, writable directories, and image availability. The deep check also starts JMeter in the configured image.
+Docker is required for `loadwright run`, `loadwright setup websocket`, `loadwright doctor`, and `loadwright doctor --deep`. The basic doctor checks verify the Docker CLI, daemon reachability, writable directories, and image availability. The deep check also starts JMeter in the configured image.
 
 Docker is not required for:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 The `examples/` directory contains runnable specs for common scenarios.
 
-Run `loadwright doctor --deep` once before running HTTP examples for the first time. WebSocket examples need the plugin-enabled image shown in the WebSocket section.
+Run `loadwright doctor --deep` once before running HTTP examples for the first time. For WebSocket examples, run `bin/loadwright setup websocket` once and verify with `bin/loadwright doctor --deep --websocket`.
 
 ## Basic API
 
@@ -102,11 +102,12 @@ Demonstrates default and request-specific timeouts.
 
 ## WebSocket Echo
 
-WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin), then reuse it for all WebSocket examples:
+WebSocket specs require a plugin-enabled JMeter image. Build it once from the bundled Dockerfile (extends `justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7` with the [WebSocket Samplers](https://github.com/ptrd/jmeter-websocket-samplers) plugin pinned in `docker/jmeter/websocket-plugin.lock`), then reuse it for all WebSocket examples:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
-bin/loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.5
+bin/loadwright setup websocket
+bin/loadwright doctor --deep --websocket
+bin/loadwright run examples/api/websocket-echo.yaml --ci
 ```
 
 Demonstrates a WebSocket request that sends one message and checks the first response.
@@ -114,8 +115,7 @@ Demonstrates a WebSocket request that sends one message and checks the first res
 ## WebSocket Multi-Message
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-multi.yaml --ci --image loadwright/jmeter-websocket:5.5
+bin/loadwright run examples/api/websocket-multi.yaml --ci
 ```
 
 Demonstrates a multi-message WebSocket sequence with delays and per-message assertions.
@@ -123,8 +123,7 @@ Demonstrates a multi-message WebSocket sequence with delays and per-message asse
 ## WebSocket Subprotocol
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .  # skip if already built
-bin/loadwright run examples/api/websocket-subprotocol.yaml --ci --image loadwright/jmeter-websocket:5.5
+bin/loadwright run examples/api/websocket-subprotocol.yaml --ci
 ```
 
 Demonstrates WebSocket subprotocol negotiation and custom handshake headers.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,15 +63,15 @@ For maintainers, an anonymous `unauthorized` response means the container image 
 
 ## WebSocket Examples
 
-WebSocket specs currently require the bundled plugin-enabled JMeter image.
+WebSocket specs require the bundled plugin-enabled JMeter image. From a source checkout or release archive, build it once and verify the plugin before running examples:
 
 ```bash
-docker build -t loadwright/jmeter-websocket:5.5 -f docker/jmeter/Dockerfile .
-loadwright doctor --deep --image loadwright/jmeter-websocket:5.5
-loadwright run examples/api/websocket-echo.yaml --ci --image loadwright/jmeter-websocket:5.5
+loadwright setup websocket
+loadwright doctor --deep --websocket
+loadwright run examples/api/websocket-echo.yaml --ci
 ```
 
-HTTP examples do not require this WebSocket image.
+If a run fails with `CannotResolveClassException` for `eu.luminis.jmeter.wssampler`, rerun the setup and doctor commands above. HTTP examples do not require this WebSocket image.
 
 ## Validate Before Running
 

--- a/examples/api/websocket-echo.yaml
+++ b/examples/api/websocket-echo.yaml
@@ -14,5 +14,4 @@ requests:
       timeout: 5s
 thresholds:
   error_rate_lt: 100
-  p95_ms_lt: 5000
-  avg_ms_lt: 3000
+  p95_ms_lt: 10000

--- a/examples/api/websocket-multi.yaml
+++ b/examples/api/websocket-multi.yaml
@@ -21,4 +21,4 @@ requests:
             timeout: 5s
 thresholds:
   error_rate_lt: 5
-  p95_ms_lt: 5000
+  p95_ms_lt: 10000

--- a/examples/api/websocket-subprotocol.yaml
+++ b/examples/api/websocket-subprotocol.yaml
@@ -19,4 +19,4 @@ requests:
             contains: ping
 thresholds:
   error_rate_lt: 100
-  p95_ms_lt: 3000
+  p95_ms_lt: 10000

--- a/examples/api/websocket-test.yaml
+++ b/examples/api/websocket-test.yaml
@@ -13,4 +13,4 @@ requests:
       timeout: 5s
 thresholds:
   error_rate_lt: 100
-  p95_ms_lt: 5000
+  p95_ms_lt: 10000

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,6 +35,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 0
 	case "doctor":
 		return doctor(args[1:], stdout, stderr)
+	case "setup":
+		return setup(args[1:], stdout, stderr)
 	case "init":
 		return initSpec(args[1:], stdout, stderr)
 	case "validate":
@@ -60,7 +62,8 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, `Loadwright: Docker-first, spec-driven JMeter automation
 
 Usage:
-  loadwright doctor [--deep] [--image IMAGE]
+  loadwright doctor [--deep] [--websocket] [--image IMAGE]
+  loadwright setup websocket [--image IMAGE] [--dockerfile docker/jmeter/Dockerfile]
   loadwright version
   loadwright init [path]
   loadwright import openapi <openapi.yaml|openapi.json> [-o loadwright.yaml] [--base-url https://api.example.com]
@@ -74,6 +77,7 @@ Usage:
 
 Commands:
   doctor    Check local Docker/JMeter prerequisites
+  setup     Prepare local runtime dependencies
   version   Print version information
   init      Write a starter YAML spec
   import    Convert supported source formats to Loadwright specs
@@ -85,13 +89,17 @@ Commands:
 }
 
 func doctor(args []string, stdout io.Writer, stderr io.Writer) int {
-	deep, image, err := parseDoctorArgs(args)
+	options, err := parseDoctorArgs(args)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
 	failed := false
-	for _, check := range runtime.Doctor(runtime.DoctorOptions{Deep: deep, Image: image}) {
+	for _, check := range runtime.Doctor(runtime.DoctorOptions{
+		Deep:      options.deep,
+		Image:     options.image,
+		WebSocket: options.webSocket,
+	}) {
 		status := "PASS"
 		if !check.Passed {
 			status = "FAIL"
@@ -105,26 +113,111 @@ func doctor(args []string, stdout io.Writer, stderr io.Writer) int {
 	return 0
 }
 
-func parseDoctorArgs(args []string) (deep bool, image string, err error) {
-	image = runtime.DefaultJMeterImage
+type doctorOptions struct {
+	deep      bool
+	image     string
+	webSocket bool
+}
+
+func parseDoctorArgs(args []string) (doctorOptions, error) {
+	var options doctorOptions
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--deep":
-			deep = true
+			options.deep = true
+		case arg == "--websocket":
+			options.webSocket = true
 		case arg == "--image":
 			i++
 			if i >= len(args) {
-				return false, "", fmt.Errorf("%s requires a value", arg)
+				return doctorOptions{}, fmt.Errorf("%s requires a value", arg)
 			}
-			image = args[i]
+			options.image = args[i]
 		case strings.HasPrefix(arg, "--image="):
-			image = strings.TrimPrefix(arg, "--image=")
+			options.image = strings.TrimPrefix(arg, "--image=")
 		default:
-			return false, "", fmt.Errorf("unknown doctor option: %s", arg)
+			return doctorOptions{}, fmt.Errorf("unknown doctor option: %s", arg)
 		}
 	}
-	return deep, image, nil
+	return options, nil
+}
+
+func setup(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "setup requires a target: websocket")
+		return 2
+	}
+	switch args[0] {
+	case "websocket":
+		return setupWebSocket(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown setup target: %s\n", args[0])
+		return 2
+	}
+}
+
+func setupWebSocket(args []string, stdout io.Writer, stderr io.Writer) int {
+	options, err := parseSetupWebSocketArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	fmt.Fprintf(stdout, "building WebSocket runtime image %s\n", options.image)
+	if err := runtime.SetupWebSocketRuntime(runtime.WebSocketSetupOptions{
+		Image:      options.image,
+		Dockerfile: options.dockerfile,
+		ContextDir: ".",
+		Stdout:     stdout,
+		Stderr:     stderr,
+	}); err != nil {
+		var runtimeErr *runtime.RuntimeError
+		if errors.As(err, &runtimeErr) {
+			writeRuntimeError(stderr, err)
+		} else {
+			fmt.Fprintf(stderr, "websocket setup failed: %v\n", err)
+		}
+		return 1
+	}
+	fmt.Fprintf(stdout, "built WebSocket runtime image %s\n", options.image)
+	fmt.Fprintln(stdout, "verify with: loadwright doctor --deep --websocket")
+	return 0
+}
+
+type setupWebSocketOptions struct {
+	image      string
+	dockerfile string
+}
+
+func parseSetupWebSocketArgs(args []string) (setupWebSocketOptions, error) {
+	options := setupWebSocketOptions{
+		image:      runtime.DefaultWebSocketJMeterImage,
+		dockerfile: runtime.WebSocketDockerfile,
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--image":
+			i++
+			if i >= len(args) {
+				return setupWebSocketOptions{}, fmt.Errorf("%s requires a value", arg)
+			}
+			options.image = args[i]
+		case strings.HasPrefix(arg, "--image="):
+			options.image = strings.TrimPrefix(arg, "--image=")
+		case arg == "--dockerfile":
+			i++
+			if i >= len(args) {
+				return setupWebSocketOptions{}, fmt.Errorf("%s requires a value", arg)
+			}
+			options.dockerfile = args[i]
+		case strings.HasPrefix(arg, "--dockerfile="):
+			options.dockerfile = strings.TrimPrefix(arg, "--dockerfile=")
+		default:
+			return setupWebSocketOptions{}, fmt.Errorf("unknown setup websocket option: %s", arg)
+		}
+	}
+	return options, nil
 }
 
 func initSpec(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -221,6 +314,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	var thresholds spec.Thresholds
 	jmxPath := input
 	generatedJMX := false
+	usesWebSocket := false
 	workDir := "."
 	if isYAML(input) {
 		loaded, err := loadResolvedSpec(input, envFile)
@@ -229,6 +323,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		thresholds = loaded.Thresholds
+		usesWebSocket = specUsesWebSocket(loaded)
 		if err := stageMultipartFiles(loaded, filepath.Dir(input), outputDir); err != nil {
 			fmt.Fprintf(stderr, "stage multipart files failed: %v\n", err)
 			return 1
@@ -243,7 +338,11 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "compiled %s\n", jmxPath)
 	}
 	if image == "" {
-		image = runtime.DefaultJMeterImage
+		if usesWebSocket {
+			image = runtime.DefaultWebSocketJMeterImage
+		} else {
+			image = runtime.DefaultJMeterImage
+		}
 	}
 
 	jtlName := "results.jtl"
@@ -356,6 +455,18 @@ func runInputType(path string) string {
 		return "yaml"
 	}
 	return "jmx"
+}
+
+func specUsesWebSocket(loaded *spec.Spec) bool {
+	if loaded == nil {
+		return false
+	}
+	for _, request := range loaded.Requests {
+		if request.Protocol == "websocket" {
+			return true
+		}
+	}
+	return false
 }
 
 type latestRun struct {
@@ -707,7 +818,6 @@ func parseValidateArgs(args []string) (specPath string, envFile string, err erro
 }
 
 func parseRunArgs(args []string) (input string, outputDir string, envFile string, ci bool, image string, err error) {
-	image = runtime.DefaultJMeterImage
 	var positional []string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,11 +3,14 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
+	goruntime "runtime"
 	"strings"
 	"testing"
+
+	loadwrightruntime "github.com/devaryakjha/loadwright/internal/runtime"
 )
 
 func TestParseCompileArgsAcceptsFlagsAfterSpec(t *testing.T) {
@@ -139,18 +142,28 @@ func TestParseCompareArgsErrors(t *testing.T) {
 }
 
 func TestParseDoctorArgs(t *testing.T) {
-	deep, image, err := parseDoctorArgs([]string{"--deep", "--image=custom:jmeter"})
+	options, err := parseDoctorArgs([]string{"--deep", "--websocket", "--image=custom:jmeter"})
 	if err != nil {
 		t.Fatalf("parseDoctorArgs() error = %v", err)
 	}
-	if !deep || image != "custom:jmeter" {
-		t.Fatalf("unexpected args: deep=%v image=%q", deep, image)
+	if !options.deep || !options.webSocket || options.image != "custom:jmeter" {
+		t.Fatalf("unexpected args: %+v", options)
 	}
 }
 
 func TestParseDoctorArgsRejectsUnknown(t *testing.T) {
-	if _, _, err := parseDoctorArgs([]string{"--unknown"}); err == nil {
+	if _, err := parseDoctorArgs([]string{"--unknown"}); err == nil {
 		t.Fatalf("expected unknown doctor option error")
+	}
+}
+
+func TestParseSetupWebSocketArgs(t *testing.T) {
+	options, err := parseSetupWebSocketArgs([]string{"--image=custom:ws", "--dockerfile", "Dockerfile.ws"})
+	if err != nil {
+		t.Fatalf("parseSetupWebSocketArgs() error = %v", err)
+	}
+	if options.image != "custom:ws" || options.dockerfile != "Dockerfile.ws" {
+		t.Fatalf("unexpected args: %+v", options)
 	}
 }
 
@@ -637,7 +650,7 @@ func TestRunCompileRejectsInvalidSpec(t *testing.T) {
 }
 
 func TestRunSpecCreatesReportsWithDockerShim(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -699,7 +712,7 @@ thresholds:
 }
 
 func TestRunSpecStagesMultipartFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -746,7 +759,7 @@ requests:
 }
 
 func TestRunSpecDefaultOutputCreatesLatestPointer(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -786,7 +799,7 @@ requests:
 }
 
 func TestRunSpecExplicitOutputDoesNotCreateLatestPointer(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -811,7 +824,7 @@ requests:
 }
 
 func TestRunSpecThresholdFailureStillCreatesLatestPointer(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -843,7 +856,7 @@ thresholds:
 }
 
 func TestRunExistingJMXCreatesRunManifest(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -866,8 +879,71 @@ func TestRunExistingJMXCreatesRunManifest(t *testing.T) {
 	}
 }
 
+func TestRunWebSocketSpecUsesDefaultWebSocketImage(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: websocket-run
+target: wss://example.com
+load:
+  users: 1
+  ramp_up: 1s
+  loops: 1
+requests:
+  - name: ping
+    protocol: websocket
+    path: /
+    websocket:
+      message: hello
+`
+	if err := os.WriteFile("websocket.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "websocket.yaml", "--out-dir", "results/ws"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run websocket) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	manifest := readRunManifest(t, filepath.Join("results", "ws", "run.json"))
+	if manifest.Image != loadwrightruntime.DefaultWebSocketJMeterImage {
+		t.Fatalf("expected websocket image, got %+v", manifest)
+	}
+}
+
+func TestRunWebSocketSpecHonorsExplicitImage(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	specYAML := `name: websocket-run
+target: wss://example.com
+requests:
+  - protocol: websocket
+    path: /
+    websocket:
+      message: hello
+`
+	if err := os.WriteFile("websocket.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "websocket.yaml", "--out-dir", "results/ws", "--image", "custom:ws"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(run websocket) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	manifest := readRunManifest(t, filepath.Join("results", "ws", "run.json"))
+	if manifest.Image != "custom:ws" {
+		t.Fatalf("expected explicit image, got %+v", manifest)
+	}
+}
+
 func TestRunManifestDoesNotIncludeEnvValues(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -904,7 +980,7 @@ requests:
 }
 
 func TestRunReportsDockerDaemonFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -931,7 +1007,7 @@ exit 0
 }
 
 func TestDoctorReportsStoppedDockerDaemon(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -962,8 +1038,61 @@ exit 0
 	}
 }
 
+func TestDoctorDeepWebSocketChecksPluginImage(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installDockerShim(t, dir)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"doctor", "--deep", "--websocket"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(doctor websocket) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "JMeter image") ||
+		!strings.Contains(stdout.String(), loadwrightruntime.DefaultWebSocketJMeterImage) ||
+		!strings.Contains(stdout.String(), "WebSocket plugin") {
+		t.Fatalf("expected websocket doctor output, got stdout=%s", stdout.String())
+	}
+}
+
+func TestSetupWebSocketBuildsDefaultImage(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	installFailingDockerShim(t, dir, fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "build" ]; then
+  printf '%%s\n' "$*" > %s
+  exit 0
+fi
+exit 1
+`, shellArg(argsFile)))
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"setup", "websocket"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(setup websocket) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := string(data)
+	if !strings.Contains(args, "build -t "+loadwrightruntime.DefaultWebSocketJMeterImage) ||
+		!strings.Contains(args, "-f "+loadwrightruntime.WebSocketDockerfile) {
+		t.Fatalf("unexpected docker build args: %s", args)
+	}
+}
+
 func TestRunReportsImagePullFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -996,8 +1125,50 @@ exit 0
 	}
 }
 
+func TestRunWebSocketSpecReportsSetupRecoveryWhenImageMissing(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("fake docker shim uses POSIX shell")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	installFailingDockerShim(t, dir, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "24.0.0"
+  exit 0
+fi
+if [ "$1" = "image" ]; then
+  exit 1
+fi
+if [ "$1" = "pull" ]; then
+  echo "repository does not exist" >&2
+  exit 1
+fi
+exit 0
+`)
+	specYAML := `name: websocket-run
+target: wss://example.com
+requests:
+  - protocol: websocket
+    path: /
+    websocket:
+      message: hello
+`
+	if err := os.WriteFile("websocket.yaml", []byte(specYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"run", "websocket.yaml", "--out-dir", "results/ws"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run(run websocket) code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "image pull failed: "+loadwrightruntime.DefaultWebSocketJMeterImage) ||
+		!strings.Contains(stderr.String(), "loadwright setup websocket") {
+		t.Fatalf("expected websocket setup recovery, got stderr=%s", stderr.String())
+	}
+}
+
 func TestRunReportsJMeterStartupFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -1031,7 +1202,7 @@ exit 0
 }
 
 func TestRunReportsTestExecutionFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if goruntime.GOOS == "windows" {
 		t.Skip("fake docker shim uses POSIX shell")
 	}
 	dir := t.TempDir()
@@ -1137,6 +1308,9 @@ for arg in "$@"; do
 done
 if [ "$1" = "run" ] && [ "$last" = "--version" ]; then
   echo "Apache JMeter 5.6.3"
+  exit 0
+fi
+if [ "$1" = "run" ] && printf '%s\n' "$*" | grep -q "test -f"; then
   exit 0
 fi
 workdir=""

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -13,7 +13,12 @@ import (
 	"strings"
 )
 
-const DefaultJMeterImage = "justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7"
+const (
+	DefaultJMeterImage          = "justb4/jmeter@sha256:088ac52b759a198a5afa5ae13d0a6306e9f2017d71ad140ff57427f6930406f7"
+	DefaultWebSocketJMeterImage = "loadwright/jmeter-websocket:5.5"
+	WebSocketDockerfile         = "docker/jmeter/Dockerfile"
+	WebSocketPluginJar          = "/opt/apache-jmeter-5.5/lib/ext/jmeter-websocket-samplers-1.3.2.jar"
+)
 
 type ErrorKind string
 
@@ -62,14 +67,27 @@ type RunOptions struct {
 }
 
 type DoctorOptions struct {
-	Image   string
-	Deep    bool
-	WorkDir string
+	Image     string
+	Deep      bool
+	WorkDir   string
+	WebSocket bool
+}
+
+type WebSocketSetupOptions struct {
+	Image      string
+	Dockerfile string
+	ContextDir string
+	Stdout     io.Writer
+	Stderr     io.Writer
 }
 
 func Doctor(options DoctorOptions) []Check {
 	if options.Image == "" {
-		options.Image = DefaultJMeterImage
+		if options.WebSocket {
+			options.Image = DefaultWebSocketJMeterImage
+		} else {
+			options.Image = DefaultJMeterImage
+		}
 	}
 	if options.WorkDir == "" {
 		options.WorkDir = "."
@@ -83,6 +101,9 @@ func Doctor(options DoctorOptions) []Check {
 	}
 	if options.Deep {
 		checks = append(checks, checkJMeterRuntime(options.Image))
+		if options.WebSocket {
+			checks = append(checks, checkWebSocketPlugin(options.Image))
+		}
 	}
 	return checks
 }
@@ -156,6 +177,37 @@ func RunJMeter(options RunOptions) error {
 	return nil
 }
 
+func SetupWebSocketRuntime(options WebSocketSetupOptions) error {
+	if options.Image == "" {
+		options.Image = DefaultWebSocketJMeterImage
+	}
+	if options.Dockerfile == "" {
+		options.Dockerfile = WebSocketDockerfile
+	}
+	if options.ContextDir == "" {
+		options.ContextDir = "."
+	}
+	if err := requireDockerDaemon(options.Image); err != nil {
+		return err
+	}
+	args := []string{"build", "-t", options.Image, "-f", options.Dockerfile, options.ContextDir}
+	cmd := exec.Command("docker", args...)
+	if options.Stdout != nil {
+		cmd.Stdout = options.Stdout
+	} else {
+		cmd.Stdout = os.Stdout
+	}
+	if options.Stderr != nil {
+		cmd.Stderr = options.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build websocket runtime image %s: %w", options.Image, err)
+	}
+	return nil
+}
+
 func checkCommand(command string, name string) Check {
 	if _, err := exec.LookPath(command); err != nil {
 		return Check{Name: name, Passed: false, Message: fmt.Sprintf("%s not found in PATH", command)}
@@ -194,6 +246,13 @@ func checkImage(image string) Check {
 	cmd := exec.Command("docker", "image", "inspect", image, "--format", "{{.Architecture}}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if image == DefaultWebSocketJMeterImage {
+			message := fmt.Sprintf("could not find %s locally. Run `loadwright setup websocket`, then retry `loadwright doctor --deep --websocket`.", image)
+			if detail := strings.TrimSpace(string(output)); detail != "" {
+				message += " Docker said: " + oneLine(detail)
+			}
+			return Check{Name: "JMeter image", Passed: false, Message: message}
+		}
 		pull := exec.Command("docker", "pull", image)
 		pullOutput, pullErr := pull.CombinedOutput()
 		if pullErr != nil {
@@ -229,6 +288,19 @@ func checkJMeterRuntime(image string) Check {
 	return Check{Name: "JMeter runtime", Passed: true, Message: version}
 }
 
+func checkWebSocketPlugin(image string) Check {
+	cmd := exec.Command("docker", "run", "--rm", "--entrypoint", "sh", image, "-c", "test -f "+shellQuote(WebSocketPluginJar))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := fmt.Sprintf("%s does not include the WebSocket Samplers plugin. Run `loadwright setup websocket`, then retry `loadwright doctor --deep --websocket`.", image)
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			message += " Docker said: " + oneLine(detail)
+		}
+		return Check{Name: "WebSocket plugin", Passed: false, Message: message}
+	}
+	return Check{Name: "WebSocket plugin", Passed: true, Message: WebSocketPluginJar + " found"}
+}
+
 func requireDockerDaemon(image string) error {
 	cmd := exec.Command("docker", "version", "--format", "{{.Server.Version}}")
 	output, err := cmd.CombinedOutput()
@@ -246,8 +318,18 @@ func requireDockerDaemon(image string) error {
 
 func ensureImage(image string) error {
 	inspect := exec.Command("docker", "image", "inspect", image, "--format", "{{.Id}}")
-	if err := inspect.Run(); err == nil {
+	inspectOutput, inspectErr := inspect.CombinedOutput()
+	if inspectErr == nil {
 		return nil
+	}
+	if image == DefaultWebSocketJMeterImage {
+		return &RuntimeError{
+			Kind:     ErrorImagePull,
+			Image:    image,
+			Cause:    inspectErr,
+			Output:   string(inspectOutput),
+			Recovery: "Run `loadwright setup websocket`, verify with `loadwright doctor --deep --websocket`, then retry. You can also pass a custom plugin-enabled image with `loadwright run ... --image <image:tag>`.",
+		}
 	}
 	pull := exec.Command("docker", "pull", image)
 	output, err := pull.CombinedOutput()
@@ -289,7 +371,7 @@ func runJMeterVersion(image string) (string, error) {
 func testExecutionRecovery(output string) string {
 	message := "Docker and JMeter started, but the test plan failed during execution. Check the generated jmeter.log in the results directory when available."
 	if looksLikeMissingWebSocketPlugin(output) {
-		message += " WebSocket specs require an image with the WebSocket Samplers plugin, for example the image built from docker/jmeter/Dockerfile."
+		message += " WebSocket specs require an image with the WebSocket Samplers plugin. Run `loadwright setup websocket`, verify with `loadwright doctor --deep --websocket`, then retry. For custom images, pass `--image <image:tag>`."
 	}
 	return message
 }
@@ -339,4 +421,11 @@ func stringTrim(value []byte) string {
 		result = result[:len(result)-1]
 	}
 	return result
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,5 +57,30 @@ func TestCheckWritableDir(t *testing.T) {
 	check := checkWritableDir(dir, "nested")
 	if !check.Passed || !strings.Contains(check.Message, "writable") {
 		t.Fatalf("unexpected check: %+v", check)
+	}
+}
+
+func TestWebSocketDockerfileEnforcesLockedChecksum(t *testing.T) {
+	lockData, err := os.ReadFile(filepath.Join("..", "..", "docker", "jmeter", "websocket-plugin.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dockerfileData, err := os.ReadFile(filepath.Join("..", "..", "docker", "jmeter", "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checksum string
+	for _, line := range strings.Split(string(lockData), "\n") {
+		if strings.HasPrefix(line, "sha256=") {
+			checksum = strings.TrimPrefix(line, "sha256=")
+			break
+		}
+	}
+	if checksum == "" {
+		t.Fatalf("websocket-plugin.lock missing sha256")
+	}
+	if !strings.Contains(string(dockerfileData), "WS_PLUGIN_SHA256="+checksum) ||
+		!strings.Contains(string(dockerfileData), "ADD --checksum=sha256:${WS_PLUGIN_SHA256}") {
+		t.Fatalf("Dockerfile does not enforce locked WebSocket plugin checksum")
 	}
 }


### PR DESCRIPTION
## Summary
- add `loadwright setup websocket` to build the bundled plugin-enabled JMeter image
- add `doctor --deep --websocket` to verify the WebSocket image and pinned plugin jar
- auto-select the local WebSocket image for WebSocket YAML specs when `--image` is not provided
- add a WebSocket plugin lockfile and include Docker runtime files in release archives
- update WebSocket docs/examples and loosen example thresholds for first-run smoke reliability

Fixes #25.

## Validation
- `go test ./...`
- `go vet ./...`
- `goreleaser check`
- `git diff --check`
- `bin/loadwright setup websocket`
- `bin/loadwright doctor --deep --websocket`
- `bin/loadwright run examples/api/websocket-echo.yaml --out-dir /tmp/loadwright-issue25-ws --ci`

Note: local Docker build/run on this arm64 Mac uses the pinned amd64 JMeter image under emulation; doctor reports that clearly.