### PR TITLE
chore(release): prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.1 - 2026-05-25
+
 - Polish the first-run documentation journey for the `v0.2.0` release.
 - Add next-step guidance after `loadwright init` creates a starter spec.
 - Add anonymous GHCR pull verification for release container images.


### PR DESCRIPTION
## Summary
- move the current unreleased changelog entries under `0.2.1 - 2026-05-25`

## Validation
- `go test ./...`
- `go vet ./...`
- `actionlint`
- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish`
- `go build -o bin/loadwright ./cmd/loadwright`
- `bin/loadwright version`
- `bin/loadwright validate examples/api/basic.yaml`
- `bin/loadwright compile examples/api/basic.yaml -o /tmp/loadwright-basic.jmx`
- `bin/loadwright run examples/api/query-params.yaml --out-dir results/release-smoke --ci`
- `bin/loadwright report results/release-smoke/results.jtl --out-dir results/release-smoke --error-rate-lt 1 --p95-ms-lt 3000 --ci`